### PR TITLE
feat: Add Query Blockchain Data Skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.claude
+.agents

--- a/skills/query-blockchain-data/SKILL.md
+++ b/skills/query-blockchain-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: query-blockchain-data
-description: Query onchain blockchain data on Base using the CDP SQL API via x402. Use when you or the user want to look up transactions, events, blocks, transfers, or any onchain data on Base. This skill helps construct CoinbaseQL queries and execute them against the CDP SQL API. Costs $0.10 per query.
+description: Query onchain blockchain data on Base using the CDP SQL API via x402. This skill helps construct CoinbaseQL queries against decoded blocks, transactions, and event.
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest balance*)", "Bash(npx awal@latest x402 pay *)"]
@@ -8,7 +8,7 @@ allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest balance*)
 
 # Query Blockchain Data on Base
 
-Use the CDP SQL API to query onchain data (events, transactions, blocks, transfers) on Base. Queries are executed via x402 and cost **$0.10 (100000 atomic units) per query**.
+Use the CDP SQL API to query onchain data (events, transactions, blocks, transfers) on Base. Queries are executed via x402 and are charged per query.
 
 ## Confirm wallet is initialized and authed
 
@@ -148,6 +148,7 @@ FROM base.events
 WHERE
   event_signature = 'Transfer(address,address,uint256)'
   AND address = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
+  AND block_timestamp >= now() - INTERVAL 7 DAY
 LIMIT 10
 ```
 
@@ -196,5 +197,4 @@ npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/ru
 
 - "Not authenticated" - Run `awal auth login <email>` first, or see `authenticate-wallet` skill
 - "Insufficient balance" - Fund wallet with USDC; see `fund` skill
-- **4xx or 5xx HTTP errors** - This most likely means your SQL query is malformed, not a wallet or payment issue. Check for syntax errors, invalid column names, missing quotes, or unescaped characters. Fix the query and retry.
-- Query timeout - Ensure you are filtering on indexed fields and using a LIMIT
+- Query timeout or error - Ensure you are filtering on indexed fields and using a LIMIT

--- a/skills/query-blockchain-data/SKILL.md
+++ b/skills/query-blockchain-data/SKILL.md
@@ -134,29 +134,21 @@ Block-level metadata.
 | transaction_count | UInt64 | Number of transactions |
 | action | Int8 | Added (1) or removed (-1) |
 
-### base.transfers
-
-Token transfer events.
-
-| Column | Type | Description |
-| --- | --- | --- |
-| block_number | UInt64 | Block number |
-| block_timestamp | DateTime64 | Block timestamp |
-| transaction_to | String | Transaction recipient |
-| transaction_from | String | Transaction sender |
-| log_index | UInt32 | Log index |
-| token_address | String | Token contract address |
-| from_address | String | Transfer sender |
-| to_address | String | Transfer recipient |
-| value | UInt256 | Transfer amount (raw) |
-| action | Enum8('added' = 1, 'removed' = -1) | Added or removed |
-
 ## Example Queries
 
-### Get recent USDC Transfer events
+### Get recent USDC Transfer events with decoded parameters
 
-```bash
-npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, block_timestamp, transaction_hash, parameters FROM base.events WHERE event_signature = '\''Transfer(address,address,uint256)'\'' AND address = lower('\''0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'\'') AND block_timestamp >= now() - INTERVAL 1 HOUR LIMIT 10"}' --json
+```sql
+SELECT
+  parameters['from'] AS sender,
+  parameters['to'] AS to,
+  parameters['value'] AS amount,
+  address AS token_address
+FROM base.events
+WHERE
+  event_signature = 'Transfer(address,address,uint256)'
+  AND address = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
+LIMIT 10
 ```
 
 ### Get transactions from a specific address
@@ -204,4 +196,5 @@ npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/ru
 
 - "Not authenticated" - Run `awal auth login <email>` first, or see `authenticate-wallet` skill
 - "Insufficient balance" - Fund wallet with USDC; see `fund` skill
-- Query timeout or error - Ensure you are filtering on indexed fields and using a LIMIT
+- **4xx or 5xx HTTP errors** - This most likely means your SQL query is malformed, not a wallet or payment issue. Check for syntax errors, invalid column names, missing quotes, or unescaped characters. Fix the query and retry.
+- Query timeout - Ensure you are filtering on indexed fields and using a LIMIT

--- a/skills/query-blockchain-data/SKILL.md
+++ b/skills/query-blockchain-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: query-blockchain-data
-description: Query onchain blockchain data on Base using the CDP SQL API via x402. This skill helps construct CoinbaseQL queries against decoded blocks, transactions, and event.
+description: Query onchain blockchain data on Base using the CDP SQL API via x402. Use when you or your user want to view onchain information about decoded blocks, transactions, and event.
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest balance*)", "Bash(npx awal@latest x402 pay *)"]

--- a/skills/query-blockchain-data/SKILL.md
+++ b/skills/query-blockchain-data/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: query-blockchain-data
+description: Query onchain blockchain data on Base using the CDP SQL API via x402. Use when you or the user want to look up transactions, events, blocks, transfers, or any onchain data on Base. This skill helps construct CoinbaseQL queries and execute them against the CDP SQL API. Costs $0.10 per query.
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest balance*)", "Bash(npx awal@latest x402 pay *)"]
+---
+
+# Query Blockchain Data on Base
+
+Use the CDP SQL API to query onchain data (events, transactions, blocks, transfers) on Base. Queries are executed via x402 and cost **$0.10 (100000 atomic units) per query**.
+
+## Confirm wallet is initialized and authed
+
+```bash
+npx awal@latest status
+```
+
+If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
+
+## Executing a Query
+
+```bash
+npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "<YOUR_QUERY>"}' --json
+```
+
+**IMPORTANT**: Always single-quote the `-d` JSON string to prevent bash variable expansion.
+
+## CRITICAL: Indexed Fields
+
+Queries against `base.events` **MUST** filter on indexed fields to avoid full table scans. The indexed fields are:
+
+| Indexed Field | Use For |
+| --- | --- |
+| `event_signature` | Filter by event type. Use this instead of `event_name` for performance. |
+| `address` | Filter by contract address. |
+| `block_timestamp` | Filter by time range. |
+
+**Always include at least one indexed field in your WHERE clause.** Combining all three gives the best performance.
+
+## CoinbaseQL Syntax
+
+CoinbaseQL is a SQL dialect based on ClickHouse. Supported features:
+
+- **Clauses**: SELECT (DISTINCT), FROM, WHERE, GROUP BY, ORDER BY (ASC/DESC), LIMIT, WITH (CTEs), UNION (ALL/DISTINCT)
+- **Joins**: INNER, LEFT, RIGHT, FULL with ON
+- **Operators**: `=`, `!=`, `<>`, `<`, `>`, `<=`, `>=`, `+`, `-`, `*`, `/`, `%`, AND, OR, NOT, BETWEEN, IN, IS NULL, LIKE
+- **Expressions**: CASE/WHEN/THEN/ELSE, CAST (both `CAST()` and `::` syntax), subqueries, array/map indexing with `[]`, dot notation
+- **Literals**: Array `[...]`, Map `{...}`, Tuple `(...)`
+- **Functions**: Standard SQL functions, lambda functions with `->` syntax
+
+## Available Tables
+
+### base.events
+
+Decoded event logs from smart contract interactions. **This is the primary table for most queries.**
+
+| Column | Type | Description |
+| --- | --- | --- |
+| log_id | String | Unique log identifier |
+| block_number | UInt64 | Block number |
+| block_hash | FixedString(66) | Block hash |
+| block_timestamp | DateTime64(3, 'UTC') | Block timestamp (**INDEXED**) |
+| transaction_hash | FixedString(66) | Transaction hash |
+| transaction_to | FixedString(42) | Transaction recipient |
+| transaction_from | FixedString(42) | Transaction sender |
+| log_index | UInt32 | Log index within block |
+| address | FixedString(42) | Contract address (**INDEXED**) |
+| topics | Array(FixedString(66)) | Event topics |
+| event_name | LowCardinality(String) | Decoded event name |
+| event_signature | LowCardinality(String) | Event signature (**INDEXED** - prefer over event_name) |
+| parameters | Map(String, Variant(Bool, Int256, String, UInt256)) | Decoded event parameters |
+| parameter_types | Map(String, String) | ABI types for parameters |
+| action | Enum8('removed' = -1, 'added' = 1) | Added or removed (reorg) |
+
+### base.transactions
+
+Complete transaction data.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| block_number | UInt64 | Block number |
+| block_hash | String | Block hash |
+| transaction_hash | String | Transaction hash |
+| transaction_index | UInt64 | Index in block |
+| from_address | String | Sender address |
+| to_address | String | Recipient address |
+| value | String | Value transferred (wei) |
+| gas | UInt64 | Gas limit |
+| gas_price | UInt64 | Gas price |
+| input | String | Input data |
+| nonce | UInt64 | Sender nonce |
+| type | UInt64 | Transaction type |
+| max_fee_per_gas | UInt64 | EIP-1559 max fee |
+| max_priority_fee_per_gas | UInt64 | EIP-1559 priority fee |
+| chain_id | UInt64 | Chain ID |
+| v | String | Signature v |
+| r | String | Signature r |
+| s | String | Signature s |
+| is_system_tx | Bool | System transaction flag |
+| max_fee_per_blob_gas | String | Blob gas fee |
+| blob_versioned_hashes | Array(String) | Blob hashes |
+| timestamp | DateTime | Block timestamp |
+| action | Int8 | Added (1) or removed (-1) |
+
+### base.blocks
+
+Block-level metadata.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| block_number | UInt64 | Block number |
+| block_hash | String | Block hash |
+| parent_hash | String | Parent block hash |
+| timestamp | DateTime | Block timestamp |
+| miner | String | Block producer |
+| nonce | UInt64 | Block nonce |
+| sha3_uncles | String | Uncles hash |
+| transactions_root | String | Transactions merkle root |
+| state_root | String | State merkle root |
+| receipts_root | String | Receipts merkle root |
+| logs_bloom | String | Bloom filter |
+| gas_limit | UInt64 | Block gas limit |
+| gas_used | UInt64 | Gas used in block |
+| base_fee_per_gas | UInt64 | Base fee per gas |
+| total_difficulty | String | Total chain difficulty |
+| size | UInt64 | Block size in bytes |
+| extra_data | String | Extra data field |
+| mix_hash | String | Mix hash |
+| withdrawals_root | String | Withdrawals root |
+| parent_beacon_block_root | String | Beacon chain parent root |
+| blob_gas_used | UInt64 | Blob gas used |
+| excess_blob_gas | UInt64 | Excess blob gas |
+| transaction_count | UInt64 | Number of transactions |
+| action | Int8 | Added (1) or removed (-1) |
+
+### base.transfers
+
+Token transfer events.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| block_number | UInt64 | Block number |
+| block_timestamp | DateTime64 | Block timestamp |
+| transaction_to | String | Transaction recipient |
+| transaction_from | String | Transaction sender |
+| log_index | UInt32 | Log index |
+| token_address | String | Token contract address |
+| from_address | String | Transfer sender |
+| to_address | String | Transfer recipient |
+| value | UInt256 | Transfer amount (raw) |
+| action | Enum8('added' = 1, 'removed' = -1) | Added or removed |
+
+## Example Queries
+
+### Get recent USDC Transfer events
+
+```bash
+npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, block_timestamp, transaction_hash, parameters FROM base.events WHERE event_signature = '\''Transfer(address,address,uint256)'\'' AND address = lower('\''0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'\'') AND block_timestamp >= now() - INTERVAL 1 HOUR LIMIT 10"}' --json
+```
+
+### Get transactions from a specific address
+
+```bash
+npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT transaction_hash, to_address, value, gas, timestamp FROM base.transactions WHERE from_address = lower('\''0xYOUR_ADDRESS'\'') AND timestamp >= now() - INTERVAL 1 DAY LIMIT 10"}' --json
+```
+
+### Count events by type for a contract in the last hour
+
+```bash
+npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT event_signature, count(*) as cnt FROM base.events WHERE address = lower('\''0xCONTRACT_ADDRESS'\'') AND block_timestamp >= now() - INTERVAL 1 HOUR GROUP BY event_signature ORDER BY cnt DESC LIMIT 20"}' --json
+```
+
+### Get latest block info
+
+```bash
+npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, timestamp, transaction_count, gas_used FROM base.blocks ORDER BY block_number DESC LIMIT 1"}' --json
+```
+
+## Common Contract Addresses (Base)
+
+| Token | Address |
+| --- | --- |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| WETH | `0x4200000000000000000000000000000000000006` |
+
+## Best Practices
+
+1. **Always filter on indexed fields** (`event_signature`, `address`, `block_timestamp`) in `base.events` queries.
+2. **Never use `SELECT *`** - specify only the columns you need.
+3. **Always include a `LIMIT`** clause to bound result size.
+4. **Use `event_signature` instead of `event_name`** for filtering - it is indexed and much faster.
+5. **Use time-bounded queries** with `block_timestamp` to narrow the scan range.
+6. **Always wrap address values in `lower()`** - the database stores lowercase addresses but users may provide checksummed (mixed-case) addresses. Use `address = lower('0xAbC...')` not `address = '0xAbC...'`.
+7. **Common event signatures**: `Transfer(address,address,uint256)`, `Approval(address,address,uint256)`, `Swap(address,uint256,uint256,uint256,uint256,address)`.
+
+## Prerequisites
+
+- Must be authenticated (`npx awal@latest status` to check, see `authenticate-wallet` skill)
+- Wallet must have sufficient USDC balance (`npx awal@latest balance` to check)
+- Each query costs $0.10 (100000 USDC atomic units)
+
+## Error Handling
+
+- "Not authenticated" - Run `awal auth login <email>` first, or see `authenticate-wallet` skill
+- "Insufficient balance" - Fund wallet with USDC; see `fund` skill
+- Query timeout or error - Ensure you are filtering on indexed fields and using a LIMIT


### PR DESCRIPTION
## Description

Adds a skill the query blockchain data using CDP's SQL API via x402.

This skill would trigger when asking for any historical onchain information, such as recent txs, common swaps, etc.

The agent will craft a SQL statement based on the skill's provided SQL grammar and DB schema and query for 10 cents.

### Testing

I installed this locally and the agent was able to craft a reasonable query based on my prompt. The agent can use the skill effectively to recognize what it needs to do, but still has some trouble crafting the query reliably. We can improve this by providing free `/grammar` and `/schema` endpoints to the agents and iterating on the skill.

```sh
⏺ Query worked but no USDC transfers from that wallet in the last hour. That wallet may not have been active recently. Want me to widen the time window (e.g., 30 days) or check for incoming transfers (parameters['to']) as well?

❯ Do both

⏺ Bash(npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, block_timestamp, transaction_hash, p…)
  ⎿  {
       "status": 200,
       "statusText": "OK",
     … +129 lines (ctrl+o to expand)
  ⎿  (timeout 30s)

⏺ Got results! Here's the USDC transfer activity for 0x65fa...19aa over the last 30 days — all incoming transfers:
  ┌───────────────┬─────────────────────────────┬───────────────┬───────────────┐
  │  Time (UTC)   │            From             │ Amount (USDC) │    Tx Hash    │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 12, 18:49 │ 0xfd79...c732               │ 0.001         │ 0x3b2f...d208 │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 12, 18:49 │ 0xfd7c...c732 (your wallet) │ 0.10          │ 0xd01d...ceca │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 12, 18:45 │ 0xfd79...c732               │ 0.001         │ 0x6fa1...6fc3 │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 12, 18:45 │ 0xfd7c...c732 (your wallet) │ 0.10          │ 0x8dbe...0b0b │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 12, 18:43 │ 0xfd79...c732               │ 0.001         │ 0x81cc...b11e │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 12, 18:43 │ 0xfd7c...c732 (your wallet) │ 0.10          │ 0xa259...9010 │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 12, 15:56 │ 0xfd7c...c732 (your wallet) │ 0.10          │ 0xb988...6b7a │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 11, 21:45 │ 0xa459...8e32               │ 0.10          │ 0x258e...59a4 │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 11, 17:15 │ 0xa459...8e32               │ 0.10          │ 0xe580...abcf │
  ├───────────────┼─────────────────────────────┼───────────────┼───────────────┤
  │ Feb 11, 17:09 │ 0xa459...8e32               │ 0.10          │ 0xd5c1...fd84 │
  └───────────────┴─────────────────────────────┴───────────────┴───────────────┘
  All transfers are inbound USDC to that wallet. The $0.10 transfers are the x402 query payment receipts — those are from your wallet and another (0xa459...) paying the CDP SQL API. The 0.001 amounts from 0xfd79... appear to be small micro-transfers (likely also x402-related fees).
```
