### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Installation
 
-Install with [Vercel's Skills CLI](https:/skills.sh):
+Install with [Vercel's Skills CLI](https://skills.sh):
 
 ```bash
 npx skills add coinbase/agentic-wallet-skills


### PR DESCRIPTION
Incorrectly written link: `https:/skills.sh` (missing `/`)
If you simply copy the link and paste it into a new line, everything works, but when you click on it in GitHub (Install with [Vercel's Skills CLI](https://github.com/skills.sh)), the link leads nowhere: `https://github.com/skills.sh` (`This page does not work. If the problem persists, contact the site owner.
HTTP ERROR 406`)