### PR TITLE
chore: pin awal and add input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 ## Available Skills
 
-| Skill | Description |
-| ----- | ----------- |
-| [authenticate-wallet](./skills/authenticate-wallet/SKILL.md) | Sign in to the wallet via email OTP |
-| [fund](./skills/fund/SKILL.md) | Add money to the wallet via Coinbase Onramp |
-| [send-usdc](./skills/send-usdc/SKILL.md) | Send USDC to Ethereum addresses or ENS names |
-| [trade](./skills/trade/SKILL.md) | Swap/trade tokens on Base (USDC, ETH, WETH) |
-| [search-for-service](./skills/search-for-service/SKILL.md) | Search the x402 bazaar for paid API services |
-| [pay-for-service](./skills/pay-for-service/SKILL.md) | Make paid API requests via x402 |
-| [monetize-service](./skills/monetize-service/SKILL.md) | Build and deploy a paid API that other agents can use via x402 |
-| [query-onchain-data](./skills/query-onchain-data/SKILL.md) | Query onchain data on Base using the CDP SQL API via x402 |
+| Skill                                                        | Description                                                    |
+| ------------------------------------------------------------ | -------------------------------------------------------------- |
+| [authenticate-wallet](./skills/authenticate-wallet/SKILL.md) | Sign in to the wallet via email OTP                            |
+| [fund](./skills/fund/SKILL.md)                               | Add money to the wallet via Coinbase Onramp                    |
+| [send-usdc](./skills/send-usdc/SKILL.md)                     | Send USDC to Ethereum addresses or ENS names                   |
+| [trade](./skills/trade/SKILL.md)                             | Swap/trade tokens on Base (USDC, ETH, WETH)                    |
+| [search-for-service](./skills/search-for-service/SKILL.md)   | Search the x402 bazaar for paid API services                   |
+| [pay-for-service](./skills/pay-for-service/SKILL.md)         | Make paid API requests via x402                                |
+| [monetize-service](./skills/monetize-service/SKILL.md)       | Build and deploy a paid API that other agents can use via x402 |
+| [query-onchain-data](./skills/query-onchain-data/SKILL.md)   | Query onchain data on Base using the CDP SQL API via x402      |
 
 ## Installation
 
@@ -45,6 +45,17 @@ To add a new skill:
 2. Add a `SKILL.md` file with YAML frontmatter and instructions
 
 See the [Agent Skills specification](https://agentskills.io/specification) for the complete format.
+
+### Updating the `awal` version
+
+All skills pin a specific version of the `awal` CLI. When a new version is published to npm, run:
+
+```bash
+# Make sure you're using Node v22+
+node ./scripts/bump-awal.js
+```
+
+This fetches the latest version from the npm registry and updates all skill files automatically.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "agentic-wallet-skills",
+  "private": true,
+  "scripts": {
+    "bump-awal": "node scripts/bump-awal.js"
+  }
+}

--- a/scripts/bump-awal.js
+++ b/scripts/bump-awal.js
@@ -9,66 +9,70 @@ const skillsDir = join(__dirname, "..", "skills");
 // Fetch latest version from npm registry
 function fetchLatestVersion() {
   return new Promise((resolve, reject) => {
-    https.get(
-      "https://registry.npmjs.org/awal/latest",
-      { headers: { Accept: "application/json" } },
-      (res) => {
-        let data = "";
-        res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => {
-          try {
-            resolve(JSON.parse(data).version);
-          } catch (e) {
-            reject(new Error(`Failed to parse npm registry response: ${e.message}`));
-          }
-        });
-      },
-    ).on("error", reject);
+    https
+      .get(
+        "https://registry.npmjs.org/awal/latest",
+        { headers: { Accept: "application/json" } },
+        (res) => {
+          let data = "";
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => {
+            try {
+              resolve(JSON.parse(data).version);
+            } catch (e) {
+              reject(
+                new Error(`Failed to parse npm registry response: ${e.message}`)
+              );
+            }
+          });
+        }
+      )
+      .on("error", reject);
   });
 }
 
 async function main() {
-const latest = await fetchLatestVersion();
-console.log(`Latest awal version: ${latest}`);
+  const latest = await fetchLatestVersion();
+  console.log(`Latest awal version: ${latest}`);
 
-const pattern = /awal@[\w.]+/g;
-let totalReplacements = 0;
-let filesChanged = 0;
+  const pattern = /awal@[\w.]+/g;
+  let totalReplacements = 0;
+  let filesChanged = 0;
 
-for (const skill of readdirSync(skillsDir, { withFileTypes: true })) {
-  if (!skill.isDirectory()) continue;
-  const filePath = join(skillsDir, skill.name, "SKILL.md");
-  let content;
-  try {
-    content = readFileSync(filePath, "utf-8");
-  } catch {
-    continue;
+  for (const skill of readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!skill.isDirectory()) continue;
+    const filePath = join(skillsDir, skill.name, "SKILL.md");
+    let content;
+    try {
+      content = readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const matches = content.match(pattern);
+    if (!matches) continue;
+
+    const alreadyCurrent = matches.every((m) => m === `awal@${latest}`);
+    if (alreadyCurrent) {
+      console.log(`  ${skill.name}: already at ${latest}`);
+      continue;
+    }
+
+    const updated = content.replace(pattern, `awal@${latest}`);
+    writeFileSync(filePath, updated);
+    const count = matches.filter((m) => m !== `awal@${latest}`).length;
+    totalReplacements += count;
+    filesChanged++;
+    console.log(`  ${skill.name}: updated ${count} references`);
   }
 
-  const matches = content.match(pattern);
-  if (!matches) continue;
-
-  const alreadyCurrent = matches.every((m) => m === `awal@${latest}`);
-  if (alreadyCurrent) {
-    console.log(`  ${skill.name}: already at ${latest}`);
-    continue;
+  if (filesChanged === 0) {
+    console.log("\nAll skills already pinned to latest.");
+  } else {
+    console.log(
+      `\nDone. Updated ${totalReplacements} references across ${filesChanged} files.`
+    );
   }
-
-  const updated = content.replace(pattern, `awal@${latest}`);
-  writeFileSync(filePath, updated);
-  const count = matches.filter((m) => m !== `awal@${latest}`).length;
-  totalReplacements += count;
-  filesChanged++;
-  console.log(`  ${skill.name}: updated ${count} references`);
-}
-
-if (filesChanged === 0) {
-  console.log("\nAll skills already pinned to latest.");
-} else {
-  console.log(
-    `\nDone. Updated ${totalReplacements} references across ${filesChanged} files.`,
-  );
-}
 }
 
 main().catch((e) => {

--- a/scripts/bump-awal.js
+++ b/scripts/bump-awal.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+const { readFileSync, writeFileSync, readdirSync } = require("fs");
+const { join } = require("path");
+const https = require("https");
+
+const skillsDir = join(__dirname, "..", "skills");
+
+// Fetch latest version from npm registry
+function fetchLatestVersion() {
+  return new Promise((resolve, reject) => {
+    https.get(
+      "https://registry.npmjs.org/awal/latest",
+      { headers: { Accept: "application/json" } },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(data).version);
+          } catch (e) {
+            reject(new Error(`Failed to parse npm registry response: ${e.message}`));
+          }
+        });
+      },
+    ).on("error", reject);
+  });
+}
+
+async function main() {
+const latest = await fetchLatestVersion();
+console.log(`Latest awal version: ${latest}`);
+
+const pattern = /awal@[\w.]+/g;
+let totalReplacements = 0;
+let filesChanged = 0;
+
+for (const skill of readdirSync(skillsDir, { withFileTypes: true })) {
+  if (!skill.isDirectory()) continue;
+  const filePath = join(skillsDir, skill.name, "SKILL.md");
+  let content;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    continue;
+  }
+
+  const matches = content.match(pattern);
+  if (!matches) continue;
+
+  const alreadyCurrent = matches.every((m) => m === `awal@${latest}`);
+  if (alreadyCurrent) {
+    console.log(`  ${skill.name}: already at ${latest}`);
+    continue;
+  }
+
+  const updated = content.replace(pattern, `awal@${latest}`);
+  writeFileSync(filePath, updated);
+  const count = matches.filter((m) => m !== `awal@${latest}`).length;
+  totalReplacements += count;
+  filesChanged++;
+  console.log(`  ${skill.name}: updated ${count} references`);
+}
+
+if (filesChanged === 0) {
+  console.log("\nAll skills already pinned to latest.");
+} else {
+  console.log(
+    `\nDone. Updated ${totalReplacements} references across ${filesChanged} files.`,
+  );
+}
+}
+
+main().catch((e) => {
+  console.error(e.message);
+  process.exit(1);
+});

--- a/skills/authenticate-wallet/SKILL.md
+++ b/skills/authenticate-wallet/SKILL.md
@@ -3,7 +3,7 @@ name: authenticate-wallet
 description: Sign in to the wallet. Use when you or the user want to log in, sign in, connect, or set up the wallet, or when any wallet operation fails with authentication or "not signed in" errors. This skill is a prerequisite before sending, trading, or funding.
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest auth *)", "Bash(npx awal@latest balance*)", "Bash(npx awal@latest address*)", "Bash(npx awal@latest show*)"]
+allowed-tools: ["Bash(npx awal@2.0.3 status*)", "Bash(npx awal@2.0.3 auth *)", "Bash(npx awal@2.0.3 balance*)", "Bash(npx awal@2.0.3 address*)", "Bash(npx awal@2.0.3 show*)"]
 ---
 
 # Authenticating with the Payments Wallet
@@ -19,7 +19,7 @@ Authentication uses a two-step email OTP process:
 ### Step 1: Initiate login
 
 ```bash
-npx awal@latest auth login <email>
+npx awal@2.0.3 auth login <email>
 ```
 
 This sends a 6-digit verification code to the email and outputs a `flowId`.
@@ -27,7 +27,7 @@ This sends a 6-digit verification code to the email and outputs a `flowId`.
 ### Step 2: Verify OTP
 
 ```bash
-npx awal@latest auth verify <flowId> <otp>
+npx awal@2.0.3 auth verify <flowId> <otp>
 ```
 
 Use the `flowId` from step 1 and the 6-digit code from the user's email to complete authentication. If you have the ability to access the user's email, you can read the OTP code, or you can ask your human for the code.
@@ -35,7 +35,7 @@ Use the `flowId` from step 1 and the 6-digit code from the user's email to compl
 ## Checking Authentication Status
 
 ```bash
-npx awal@latest status
+npx awal@2.0.3 status
 ```
 
 Displays wallet server health and authentication status including wallet address.
@@ -44,36 +44,36 @@ Displays wallet server health and authentication status including wallet address
 
 ```bash
 # Check current status
-npx awal@latest status
+npx awal@2.0.3 status
 
 # Start login (sends OTP to email)
-npx awal@latest auth login user@example.com
+npx awal@2.0.3 auth login user@example.com
 # Output: flowId: abc123...
 
 # After user receives code, verify
-npx awal@latest auth verify abc123 123456
+npx awal@2.0.3 auth verify abc123 123456
 
 # Confirm authentication
-npx awal@latest status
+npx awal@2.0.3 status
 ```
 
 ## Available CLI Commands
 
 | Command                                      | Purpose                                |
 | -------------------------------------------- | -------------------------------------- |
-| `npx awal@latest status`                     | Check server health and auth status    |
-| `npx awal@latest auth login <email>`         | Send OTP code to email, returns flowId |
-| `npx awal@latest auth verify <flowId> <otp>` | Complete authentication with OTP code  |
-| `npx awal@latest balance`                    | Get USDC wallet balance                |
-| `npx awal@latest address`                    | Get wallet address                     |
-| `npx awal@latest show`                       | Open the wallet companion window       |
+| `npx awal@2.0.3 status`                     | Check server health and auth status    |
+| `npx awal@2.0.3 auth login <email>`         | Send OTP code to email, returns flowId |
+| `npx awal@2.0.3 auth verify <flowId> <otp>` | Complete authentication with OTP code  |
+| `npx awal@2.0.3 balance`                    | Get USDC wallet balance                |
+| `npx awal@2.0.3 address`                    | Get wallet address                     |
+| `npx awal@2.0.3 show`                       | Open the wallet companion window       |
 
 ## JSON Output
 
 All commands support `--json` for machine-readable output:
 
 ```bash
-npx awal@latest status --json
-npx awal@latest auth login user@example.com --json
-npx awal@latest auth verify <flowId> <otp> --json
+npx awal@2.0.3 status --json
+npx awal@2.0.3 auth login user@example.com --json
+npx awal@2.0.3 auth verify <flowId> <otp> --json
 ```

--- a/skills/authenticate-wallet/SKILL.md
+++ b/skills/authenticate-wallet/SKILL.md
@@ -32,6 +32,16 @@ npx awal@2.0.3 auth verify <flowId> <otp>
 
 Use the `flowId` from step 1 and the 6-digit code from the user's email to complete authentication. If you have the ability to access the user's email, you can read the OTP code, or you can ask your human for the code.
 
+## Input Validation
+
+Before constructing the command, validate all user-provided values to prevent shell injection:
+
+- **email**: Must match a standard email format (`^[^\s;|&`]+@[^\s;|&`]+$`). Reject if it contains spaces, semicolons, pipes, backticks, or other shell metacharacters.
+- **flowId**: Must be alphanumeric (`^[a-zA-Z0-9_-]+$`).
+- **otp**: Must be exactly 6 digits (`^\d{6}$`).
+
+Do not pass unvalidated user input into the command.
+
 ## Checking Authentication Status
 
 ```bash

--- a/skills/fund/SKILL.md
+++ b/skills/fund/SKILL.md
@@ -3,7 +3,7 @@ name: fund
 description: Add money to the wallet. Use when you or the user want to fund, deposit, top up, load, buy USDC, add funds, onramp, or get USDC. Also use when the wallet has insufficient balance for a send or trade operation, or when someone asks "how do I get USDC?"
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest show*)", "Bash(npx awal@latest address*)", "Bash(npx awal@latest balance*)"]
+allowed-tools: ["Bash(npx awal@2.0.3 status*)", "Bash(npx awal@2.0.3 show*)", "Bash(npx awal@2.0.3 address*)", "Bash(npx awal@2.0.3 balance*)"]
 ---
 
 # Funding the Wallet
@@ -13,7 +13,7 @@ Use the wallet companion app to fund the wallet with USDC via Coinbase Onramp. T
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@latest status
+npx awal@2.0.3 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,7 +21,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Opening the Funding Interface
 
 ```bash
-npx awal@latest show
+npx awal@2.0.3 show
 ```
 
 This opens the wallet companion window where users can:
@@ -44,17 +44,17 @@ This opens the wallet companion window where users can:
 You can also ask your human to send usdc on Base to your wallet address. You can find your wallet address buy running the following:
 
 ```bash
-npx awal@latest address
+npx awal@2.0.3 address
 ```
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@latest status` to check)
+- Must be authenticated (`npx awal@2.0.3 status` to check)
 - Coinbase Onramp is available in supported regions (US, etc.)
 
 ## Flow
 
-1. Run `npx awal@latest show` to open the wallet UI
+1. Run `npx awal@2.0.3 show` to open the wallet UI
 2. Instruct the user to click the Fund button
 3. User selects amount and payment method in the UI
 4. User completes payment through Coinbase Pay (opens in browser)
@@ -64,7 +64,7 @@ npx awal@latest address
 
 ```bash
 # Check updated balance
-npx awal@latest balance
+npx awal@2.0.3 balance
 ```
 
 ## Notes

--- a/skills/monetize-service/SKILL.md
+++ b/skills/monetize-service/SKILL.md
@@ -3,7 +3,7 @@ name: monetize-service
 description: Build and deploy a paid API that other agents can pay to use via x402. Use when you or the user want to monetize an API, make money, earn money, offer a service, sell a service to other agents, charge for endpoints, create a paid endpoint, or set up a paid service. Covers "make money by offering an endpoint", "sell a service", "monetize your data", "create a paid API".
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest address*)", "Bash(npx awal@latest x402 details *)", "Bash(npx awal@latest x402 pay *)", "Bash(npm *)", "Bash(node *)", "Bash(curl *)", "Bash(mkdir *)"]
+allowed-tools: ["Bash(npx awal@2.0.3 status*)", "Bash(npx awal@2.0.3 address*)", "Bash(npx awal@2.0.3 x402 details *)", "Bash(npx awal@2.0.3 x402 pay *)", "Bash(npm *)", "Bash(node *)", "Bash(curl *)", "Bash(mkdir *)"]
 ---
 
 # Build an x402 Payment Server
@@ -17,7 +17,7 @@ x402 is an HTTP-native payment protocol. When a client hits a protected endpoint
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@latest status
+npx awal@2.0.3 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -27,7 +27,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 Run this to get the wallet address that will receive payments:
 
 ```bash
-npx awal@latest address
+npx awal@2.0.3 address
 ```
 
 Use this address as the `payTo` value.
@@ -380,10 +380,10 @@ Once the server is running, use the `pay-for-service` skill to test payments:
 
 ```bash
 # Check the endpoint's payment requirements
-npx awal@latest x402 details http://localhost:3000/api/example
+npx awal@2.0.3 x402 details http://localhost:3000/api/example
 
 # Make a paid request
-npx awal@latest x402 pay http://localhost:3000/api/example
+npx awal@2.0.3 x402 pay http://localhost:3000/api/example
 ```
 
 ## Pricing Guidelines
@@ -397,11 +397,11 @@ npx awal@latest x402 pay http://localhost:3000/api/example
 
 ## Checklist
 
-- [ ] Get wallet address with `npx awal@latest address`
+- [ ] Get wallet address with `npx awal@2.0.3 address`
 - [ ] Install `express`, `@x402/express`, `@x402/core`, `@x402/evm`, and `@x402/extensions`
 - [ ] Create `x402ResourceServer` with facilitator client and register `ExactEvmScheme` for `eip155:8453`
 - [ ] Define routes with prices, descriptions, and discovery extensions (Bazaar auto-registers when routes declare it)
 - [ ] Register payment middleware before protected routes
 - [ ] Keep health/status endpoints before payment middleware
-- [ ] Test with `curl` (should get 402) and `npx awal@latest x402 pay` (should get 200)
+- [ ] Test with `curl` (should get 402) and `npx awal@2.0.3 x402 pay` (should get 200)
 - [ ] Announce your service so other agents can find and use it

--- a/skills/pay-for-service/SKILL.md
+++ b/skills/pay-for-service/SKILL.md
@@ -49,6 +49,16 @@ X402 uses USDC atomic units (6 decimals):
 
 **IMPORTANT**: Always single-quote amounts that use `$` to prevent bash variable expansion (e.g. `'$1.00'` not `$1.00`).
 
+## Input Validation
+
+Before constructing the command, validate all user-provided values to prevent shell injection:
+
+- **url**: Must be a valid URL starting with `https://` or `http://`. Reject if it contains spaces, semicolons, pipes, backticks, or shell metacharacters.
+- **data (-d)**: Must be valid JSON. Always wrap in single quotes to prevent shell expansion.
+- **max-amount**: Must be a positive integer (`^\d+$`).
+
+Do not pass unvalidated user input into the command.
+
 ## Examples
 
 ```bash

--- a/skills/pay-for-service/SKILL.md
+++ b/skills/pay-for-service/SKILL.md
@@ -3,17 +3,17 @@ name: pay-for-service
 description: Make a paid API request to an x402 endpoint with automatic USDC payment. Use when you or the user want to call a paid API, make an x402 request, use a paid service, or pay for an API call. Use after finding a service with search-for-service.
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest balance*)", "Bash(npx awal@latest x402 pay *)"]
+allowed-tools: ["Bash(npx awal@2.0.3 status*)", "Bash(npx awal@2.0.3 balance*)", "Bash(npx awal@2.0.3 x402 pay *)"]
 ---
 
 # Making Paid x402 Requests
 
-Use the `npx awal@latest x402 pay` command to call paid API endpoints with automatic USDC payment on Base.
+Use the `npx awal@2.0.3 x402 pay` command to call paid API endpoints with automatic USDC payment on Base.
 
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@latest status
+npx awal@2.0.3 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,7 +21,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Command Syntax
 
 ```bash
-npx awal@latest x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>] [--max-amount <n>] [--json]
+npx awal@2.0.3 x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>] [--max-amount <n>] [--json]
 ```
 
 ## Options
@@ -53,19 +53,19 @@ X402 uses USDC atomic units (6 decimals):
 
 ```bash
 # Make a GET request (auto-pays)
-npx awal@latest x402 pay https://example.com/api/weather
+npx awal@2.0.3 x402 pay https://example.com/api/weather
 
 # Make a POST request with body
-npx awal@latest x402 pay https://example.com/api/sentiment -X POST -d '{"text": "I love this product"}'
+npx awal@2.0.3 x402 pay https://example.com/api/sentiment -X POST -d '{"text": "I love this product"}'
 
 # Limit max payment to $0.10
-npx awal@latest x402 pay https://example.com/api/data --max-amount 100000
+npx awal@2.0.3 x402 pay https://example.com/api/data --max-amount 100000
 ```
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@latest status` to check, see `authenticate-wallet` skill)
-- Wallet must have sufficient USDC balance (`npx awal@latest balance` to check)
+- Must be authenticated (`npx awal@2.0.3 status` to check, see `authenticate-wallet` skill)
+- Wallet must have sufficient USDC balance (`npx awal@2.0.3 balance` to check)
 - If you don't know the endpoint URL, use the `search-for-service` skill to find services first
 
 ## Error Handling

--- a/skills/query-onchain-data/SKILL.md
+++ b/skills/query-onchain-data/SKILL.md
@@ -26,6 +26,15 @@ npx awal@2.0.3 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run
 
 **IMPORTANT**: Always single-quote the `-d` JSON string to prevent bash variable expansion.
 
+## Input Validation
+
+Before constructing the command, validate inputs to prevent shell injection:
+
+- **SQL query**: Always embed the query inside a single-quoted JSON string (`-d '{"sql": "..."}'`). Never use double quotes for the outer `-d` wrapper, as this enables shell expansion of `$` and backticks within the query.
+- **Addresses**: Must be valid `0x` hex addresses (`^0x[0-9a-fA-F]{40}$`). Reject any value containing shell metacharacters.
+
+Do not pass unvalidated user input into the command.
+
 ## CRITICAL: Indexed Fields
 
 Queries against `base.events` **MUST** filter on indexed fields to avoid full table scans. The indexed fields are:

--- a/skills/query-onchain-data/SKILL.md
+++ b/skills/query-onchain-data/SKILL.md
@@ -3,7 +3,7 @@ name: query-onchain-data
 description: Query onchain data on Base using the CDP SQL API via x402. Use when you or your user want to view onchain information about decoded blocks, transactions, and event.
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest balance*)", "Bash(npx awal@latest x402 pay *)"]
+allowed-tools: ["Bash(npx awal@2.0.3 status*)", "Bash(npx awal@2.0.3 balance*)", "Bash(npx awal@2.0.3 x402 pay *)"]
 ---
 
 # Query Onchain Data on Base
@@ -13,7 +13,7 @@ Use the CDP SQL API to query onchain data (events, transactions, blocks, transfe
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@latest status
+npx awal@2.0.3 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,7 +21,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Executing a Query
 
 ```bash
-npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "<YOUR_QUERY>"}' --json
+npx awal@2.0.3 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "<YOUR_QUERY>"}' --json
 ```
 
 **IMPORTANT**: Always single-quote the `-d` JSON string to prevent bash variable expansion.
@@ -155,19 +155,19 @@ LIMIT 10
 ### Get transactions from a specific address
 
 ```bash
-npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT transaction_hash, to_address, value, gas, timestamp FROM base.transactions WHERE from_address = lower('\''0xYOUR_ADDRESS'\'') AND timestamp >= now() - INTERVAL 1 DAY LIMIT 10"}' --json
+npx awal@2.0.3 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT transaction_hash, to_address, value, gas, timestamp FROM base.transactions WHERE from_address = lower('\''0xYOUR_ADDRESS'\'') AND timestamp >= now() - INTERVAL 1 DAY LIMIT 10"}' --json
 ```
 
 ### Count events by type for a contract in the last hour
 
 ```bash
-npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT event_signature, count(*) as cnt FROM base.events WHERE address = lower('\''0xCONTRACT_ADDRESS'\'') AND block_timestamp >= now() - INTERVAL 1 HOUR GROUP BY event_signature ORDER BY cnt DESC LIMIT 20"}' --json
+npx awal@2.0.3 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT event_signature, count(*) as cnt FROM base.events WHERE address = lower('\''0xCONTRACT_ADDRESS'\'') AND block_timestamp >= now() - INTERVAL 1 HOUR GROUP BY event_signature ORDER BY cnt DESC LIMIT 20"}' --json
 ```
 
 ### Get latest block info
 
 ```bash
-npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, timestamp, transaction_count, gas_used FROM base.blocks ORDER BY block_number DESC LIMIT 1"}' --json
+npx awal@2.0.3 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, timestamp, transaction_count, gas_used FROM base.blocks ORDER BY block_number DESC LIMIT 1"}' --json
 ```
 
 ## Common Contract Addresses (Base)
@@ -189,8 +189,8 @@ npx awal@latest x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/ru
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@latest status` to check, see `authenticate-wallet` skill)
-- Wallet must have sufficient USDC balance (`npx awal@latest balance` to check)
+- Must be authenticated (`npx awal@2.0.3 status` to check, see `authenticate-wallet` skill)
+- Wallet must have sufficient USDC balance (`npx awal@2.0.3 balance` to check)
 - Each query costs $0.10 (100000 USDC atomic units)
 
 ## Error Handling

--- a/skills/search-for-service/SKILL.md
+++ b/skills/search-for-service/SKILL.md
@@ -3,12 +3,12 @@ name: search-for-service
 description: Search and browse the x402 bazaar marketplace for paid API services. Use when you or the user want to find available services, see what's available, discover APIs, or need an external service to accomplish a task. Also use as a fallback when no other skill clearly matches — search the bazaar to see if a paid service exists. Covers "what can I do?", "find me an API for...", "what services are available?", "search for...", "browse the bazaar".
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@latest x402 bazaar *)", "Bash(npx awal@latest x402 details *)"]
+allowed-tools: ["Bash(npx awal@2.0.3 x402 bazaar *)", "Bash(npx awal@2.0.3 x402 details *)"]
 ---
 
 # Searching the x402 Bazaar
 
-Use the `npx awal@latest x402` commands to discover and inspect paid API endpoints available on the x402 bazaar marketplace. No authentication or balance is required for searching.
+Use the `npx awal@2.0.3 x402` commands to discover and inspect paid API endpoints available on the x402 bazaar marketplace. No authentication or balance is required for searching.
 
 ## Commands
 
@@ -17,7 +17,7 @@ Use the `npx awal@latest x402` commands to discover and inspect paid API endpoin
 Find paid services by keyword using BM25 relevance search:
 
 ```bash
-npx awal@latest x402 bazaar search <query> [-k <n>] [--force-refresh] [--json]
+npx awal@2.0.3 x402 bazaar search <query> [-k <n>] [--force-refresh] [--json]
 ```
 
 | Option            | Description                          |
@@ -33,7 +33,7 @@ Results are cached locally at `~/.config/awal/bazaar/` and auto-refresh after 12
 Browse all available resources:
 
 ```bash
-npx awal@latest x402 bazaar list [--network <network>] [--full] [--json]
+npx awal@2.0.3 x402 bazaar list [--network <network>] [--full] [--json]
 ```
 
 | Option             | Description                             |
@@ -47,7 +47,7 @@ npx awal@latest x402 bazaar list [--network <network>] [--full] [--json]
 Inspect an endpoint's x402 payment requirements without paying:
 
 ```bash
-npx awal@latest x402 details <url> [--json]
+npx awal@2.0.3 x402 details <url> [--json]
 ```
 
 Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying each until it gets a 402 response, then displays price, accepted payment schemes, network, and input/output schemas.
@@ -56,16 +56,16 @@ Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying e
 
 ```bash
 # Search for weather-related paid APIs
-npx awal@latest x402 bazaar search "weather"
+npx awal@2.0.3 x402 bazaar search "weather"
 
 # Search with more results
-npx awal@latest x402 bazaar search "sentiment analysis" -k 10
+npx awal@2.0.3 x402 bazaar search "sentiment analysis" -k 10
 
 # Browse all bazaar resources with full details
-npx awal@latest x402 bazaar list --full
+npx awal@2.0.3 x402 bazaar list --full
 
 # Check what an endpoint costs
-npx awal@latest x402 details https://example.com/api/weather
+npx awal@2.0.3 x402 details https://example.com/api/weather
 ```
 
 ## Prerequisites

--- a/skills/send-usdc/SKILL.md
+++ b/skills/send-usdc/SKILL.md
@@ -38,6 +38,15 @@ npx awal@2.0.3 send <amount> <recipient> [--chain <chain>] [--json]
 | `--chain <name>` | Blockchain network (default: base) |
 | `--json`         | Output result as JSON              |
 
+## Input Validation
+
+Before constructing the command, validate all user-provided values to prevent shell injection:
+
+- **amount**: Must match `^\$?[\d.]+$` (digits, optional decimal point, optional `$` prefix). Reject if it contains spaces, semicolons, pipes, backticks, or other shell metacharacters.
+- **recipient**: Must be a valid `0x` hex address (`^0x[0-9a-fA-F]{40}$`) or an ENS name (`^[a-zA-Z0-9.-]+\.eth$`). Reject any value containing spaces or shell metacharacters.
+
+Do not pass unvalidated user input into the command.
+
 ## Examples
 
 ```bash

--- a/skills/send-usdc/SKILL.md
+++ b/skills/send-usdc/SKILL.md
@@ -3,17 +3,17 @@ name: send-usdc
 description: Send USDC to an Ethereum address or ENS name. Use when you or the user want to send money, pay someone, transfer USDC, tip, donate, or send funds to a wallet address or .eth name. Covers phrases like "send $5 to", "pay 0x...", or "transfer to vitalik.eth".
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest send *)", "Bash(npx awal@latest balance*)"]
+allowed-tools: ["Bash(npx awal@2.0.3 status*)", "Bash(npx awal@2.0.3 send *)", "Bash(npx awal@2.0.3 balance*)"]
 ---
 
 # Sending USDC
 
-Use the `npx awal@latest send` command to transfer USDC from the wallet to any Ethereum address or ENS name on Base.
+Use the `npx awal@2.0.3 send` command to transfer USDC from the wallet to any Ethereum address or ENS name on Base.
 
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@latest status
+npx awal@2.0.3 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,7 +21,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Command Syntax
 
 ```bash
-npx awal@latest send <amount> <recipient> [--chain <chain>] [--json]
+npx awal@2.0.3 send <amount> <recipient> [--chain <chain>] [--json]
 ```
 
 ## Arguments
@@ -42,16 +42,16 @@ npx awal@latest send <amount> <recipient> [--chain <chain>] [--json]
 
 ```bash
 # Send $1.00 USDC to an address
-npx awal@latest send 1 0x1234...abcd
+npx awal@2.0.3 send 1 0x1234...abcd
 
 # Send $0.50 USDC to an ENS name
-npx awal@latest send 0.50 vitalik.eth
+npx awal@2.0.3 send 0.50 vitalik.eth
 
 # Send with dollar sign prefix (note the single quotes)
-npx awal@latest send '$5.00' 0x1234...abcd
+npx awal@2.0.3 send '$5.00' 0x1234...abcd
 
 # Get JSON output
-npx awal@latest send 1 vitalik.eth --json
+npx awal@2.0.3 send 1 vitalik.eth --json
 ```
 
 ## ENS Resolution
@@ -64,7 +64,7 @@ ENS names are automatically resolved to addresses via Ethereum mainnet. The comm
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@latest awal status` to check, `npx awal@latest awal auth login` to sign in, see skill `authenticate-wallet` for more information)
+- Must be authenticated (`npx awal@2.0.3 awal status` to check, `npx awal@2.0.3 awal auth login` to sign in, see skill `authenticate-wallet` for more information)
 - Wallet must have sufficient USDC balance (`npx awal balance` to check)
 
 ## Error Handling

--- a/skills/send-usdc/SKILL.md
+++ b/skills/send-usdc/SKILL.md
@@ -73,7 +73,7 @@ ENS names are automatically resolved to addresses via Ethereum mainnet. The comm
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.0.3 awal status` to check, `npx awal@2.0.3 awal auth login` to sign in, see skill `authenticate-wallet` for more information)
+- Must be authenticated (`npx awal@2.0.3 status` to check, `npx awal@2.0.3 auth login` to sign in, see skill `authenticate-wallet` for more information)
 - Wallet must have sufficient USDC balance (`npx awal balance` to check)
 
 ## Error Handling

--- a/skills/trade/SKILL.md
+++ b/skills/trade/SKILL.md
@@ -3,17 +3,17 @@ name: trade
 description: Swap or trade tokens on Base network. Use when you or the user want to trade, swap, exchange, buy, sell, or convert between tokens like USDC, ETH, and WETH. Covers phrases like "buy ETH", "sell ETH for USDC", "convert USDC to ETH", "get some ETH".
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest trade *)", "Bash(npx awal@latest balance*)"]
+allowed-tools: ["Bash(npx awal@2.0.3 status*)", "Bash(npx awal@2.0.3 trade *)", "Bash(npx awal@2.0.3 balance*)"]
 ---
 
 # Trading Tokens
 
-Use the `npx awal@latest trade` command to swap tokens on Base network via the CDP Swap API. You must be authenticated to trade.
+Use the `npx awal@2.0.3 trade` command to swap tokens on Base network via the CDP Swap API. You must be authenticated to trade.
 
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@latest status
+npx awal@2.0.3 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,7 +21,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Command Syntax
 
 ```bash
-npx awal@latest trade <amount> <from> <to> [options]
+npx awal@2.0.3 trade <amount> <from> <to> [options]
 ```
 
 ## Arguments
@@ -69,25 +69,25 @@ The amount can be specified in multiple formats:
 
 ```bash
 # Swap $1 USDC for ETH (dollar prefix — note the single quotes)
-npx awal@latest trade '$1' usdc eth
+npx awal@2.0.3 trade '$1' usdc eth
 
 # Swap 0.50 USDC for ETH (decimal format)
-npx awal@latest trade 0.50 usdc eth
+npx awal@2.0.3 trade 0.50 usdc eth
 
 # Swap 500000 atomic units of USDC for ETH
-npx awal@latest trade 500000 usdc eth
+npx awal@2.0.3 trade 500000 usdc eth
 
 # Swap 0.01 ETH for USDC
-npx awal@latest trade 0.01 eth usdc
+npx awal@2.0.3 trade 0.01 eth usdc
 
 # Swap with custom slippage (2%)
-npx awal@latest trade '$5' usdc eth --slippage 200
+npx awal@2.0.3 trade '$5' usdc eth --slippage 200
 
 # Swap using contract addresses (decimals read from chain)
-npx awal@latest trade 100 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 0x4200000000000000000000000000000000000006
+npx awal@2.0.3 trade 100 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 0x4200000000000000000000000000000000000006
 
 # Get JSON output
-npx awal@latest trade '$1' usdc eth --json
+npx awal@2.0.3 trade '$1' usdc eth --json
 ```
 
 ## Prerequisites

--- a/skills/trade/SKILL.md
+++ b/skills/trade/SKILL.md
@@ -65,6 +65,16 @@ The amount can be specified in multiple formats:
 
 **IMPORTANT**: Always single-quote amounts that use `$` to prevent bash variable expansion (e.g. `'$1.00'` not `$1.00`).
 
+## Input Validation
+
+Before constructing the command, validate all user-provided values to prevent shell injection:
+
+- **amount**: Must match `^\$?[\d.]+$` (digits, optional decimal point, optional `$` prefix). Reject if it contains spaces, semicolons, pipes, backticks, or other shell metacharacters.
+- **from / to**: Must be a known alias (`usdc`, `eth`, `weth`) or a valid `0x` hex address (`^0x[0-9a-fA-F]{40}$`). Reject any other value.
+- **slippage**: Must be a positive integer (`^\d+$`).
+
+Do not pass unvalidated user input into the command.
+
 ## Examples
 
 ```bash

--- a/skills/x402/SKILL.md
+++ b/skills/x402/SKILL.md
@@ -7,7 +7,7 @@ disable-model-invocation: false
 
 # x402 Payment Protocol
 
-Use the `npx awal@latest x402` commands to discover, inspect, and call paid API endpoints using the X402 payment protocol. Payments are made in USDC on Base.
+Use the `npx awal@2.0.3 x402` commands to discover, inspect, and call paid API endpoints using the X402 payment protocol. Payments are made in USDC on Base.
 
 ## Workflow
 
@@ -24,7 +24,7 @@ The typical x402 workflow is:
 Find paid services by keyword using BM25 relevance search:
 
 ```bash
-npx awal@latest x402 bazaar search <query> [-k <n>] [--force-refresh] [--json]
+npx awal@2.0.3 x402 bazaar search <query> [-k <n>] [--force-refresh] [--json]
 ```
 
 | Option            | Description                          |


### PR DESCRIPTION
<!--
Thanks for contributing to Coinbase Agent Wallet Skills!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Following [vercel security audit](https://skills.sh/coinbase/agentic-wallet-skills/trade/security/agent-trust-hub) on our skills, the standard approach is to pin the exact version of awal. The tradeoff here is that users will have to re-download the skill(s) when new versions of awal are published.

Bumping the pinned version can be done easily with a new script added in the PR by running:
```
node ./scripts/bump-awal.js
```

Also adds input validation.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
 -->
