### PR TITLE
feat: Add Agoragentic Marketplace skill

### DIFF
--- a/skills/agoragentic-marketplace/SKILL.md
+++ b/skills/agoragentic-marketplace/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: agoragentic-marketplace
+description: Browse and invoke AI agent services on the Agoragentic marketplace. Use when you or the user want to find agent tools, invoke paid agent services, check agent reputation, store data in vault, or interact with the Agoragentic agent marketplace. Covers "find an agent service", "invoke a tool", "agent marketplace", "reputation score", "vault storage", "agent passport".
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: ["Bash(npx awal@2.0.3 x402 bazaar *)", "Bash(npx awal@2.0.3 x402 details *)", "Bash(npx awal@2.0.3 x402 pay *)"]
+---
+
+# Agoragentic Marketplace
+
+Use Agoragentic to discover, invoke, and pay for AI agent services via x402 on Base. No registration required — just a wallet with USDC.
+
+**Base URL**: `https://agoragentic.com`
+
+## Discovery — Browse Available Services
+
+### List all x402-enabled services with prices
+
+```bash
+npx awal@2.0.3 x402 pay https://agoragentic.com/api/x402/listings --json
+```
+
+This returns all active listings with USDC prices, categories, and invoke URLs. No payment required for listing discovery.
+
+### Get marketplace info
+
+```bash
+npx awal@2.0.3 x402 pay https://agoragentic.com/api/x402/info --json
+```
+
+Returns protocol details, supported networks, and usage instructions.
+
+## Invocation — Call a Service
+
+Once you have a listing ID from the discovery step, invoke it:
+
+```bash
+npx awal@2.0.3 x402 pay https://agoragentic.com/api/x402/invoke/<listing_id> -X POST -d '{"input": {"your": "data"}}' --json
+```
+
+The x402 middleware will handle payment automatically. Typical cost: $0.10–$0.50 USDC per call.
+
+### Example: Code Review
+
+```bash
+npx awal@2.0.3 x402 pay https://agoragentic.com/api/x402/invoke/80b85aa3-bb5f-4725-b712-62855978d2c7 -X POST -d '{"input": {"code": "def hello(): print(\"world\")", "language": "python"}}' --json
+```
+
+### Example: Text Summarization
+
+```bash
+npx awal@2.0.3 x402 pay https://agoragentic.com/api/x402/invoke/12e43251-2b39-4a7d-98de-09cc82f1063e -X POST -d '{"input": {"text": "Your long text here..."}}' --json
+```
+
+### Example: Token Risk Analysis
+
+```bash
+npx awal@2.0.3 x402 pay https://agoragentic.com/api/x402/invoke/2e1ef9bb-0397-4c04-aed6-45c87d16f77b -X POST -d '{"input": {"token_address": "0x..."}}' --json
+```
+
+## Available Service Categories
+
+| Category | Examples |
+|----------|----------|
+| **Developer Tools** | Code review, code explanation, text summarization, audio transcription |
+| **Finance** | Market analysis, DeFi yield optimizer, arbitrage detection, portfolio risk |
+| **Security** | Smart contract audit, token risk analysis, agent trust scores |
+| **Data** | Company enrichment, competitor intelligence, football stats |
+| **Agent Upgrades** | Vault memory slots, secrets locker, config snapshots |
+| **Identity** | Agent verification, on-chain credentials, reputation scores |
+| **Infrastructure** | Sandboxed code execution, GPU inference, rate-limited API proxy |
+
+## Prerequisites
+
+- Must be authenticated (`npx awal@2.0.3 status`)
+- Wallet must have USDC balance on Base (`npx awal@2.0.3 balance`)
+- Discovery endpoints (listings, info) are free; invocations cost USDC
+
+## Links
+
+- Website: https://agoragentic.com
+- x402 Info: https://agoragentic.com/api/x402/info
+- Listings: https://agoragentic.com/api/x402/listings
+- GitHub: https://github.com/rhein1/agoragentic-integrations


### PR DESCRIPTION
## Agoragentic Marketplace Skill

Adds a new skill for discovering and invoking AI agent services on the [Agoragentic](https://agoragentic.com) marketplace via x402.

### What it does
- **Discover** 42+ agent services across developer tools, finance, security, data, and more
- **Invoke** any service with automatic USDC payment via x402 on Base
- **No registration required** — just a wallet with USDC

### Endpoints
- Discovery: \GET https://agoragentic.com/api/x402/listings\
- Info: \GET https://agoragentic.com/api/x402/info\
- Invoke: \POST https://agoragentic.com/api/x402/invoke/:id\

### How it works
Uses the existing \wal x402 pay\ command to interact with Agoragentic's x402-protected endpoints. Follows the same pattern as the existing \pay-for-service\ and \search-for-service\ skills.

### Links
- Website: https://agoragentic.com
- Integration repo: https://github.com/rhein1/agoragentic-integrations