### PR TITLE
chore: bump awal to v2.10.0 and align skills with current CLI

### DIFF
--- a/skills/authenticate-wallet/SKILL.md
+++ b/skills/authenticate-wallet/SKILL.md
@@ -3,10 +3,10 @@ name: authenticate-wallet
 description: Sign in to the wallet. Use when you or the user want to log in, sign in, connect, or set up the wallet, or when any wallet operation fails with authentication or "not signed in" errors. This skill is a prerequisite before sending, trading, or funding.
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@2.8.2 status*)", "Bash(npx awal@2.8.2 auth *)", "Bash(npx awal@2.8.2 balance*)", "Bash(npx awal@2.8.2 address*)", "Bash(npx awal@2.8.2 show*)"]
+allowed-tools: ["Bash(npx awal@2.10.0 status*)", "Bash(npx awal@2.10.0 auth *)", "Bash(npx awal@2.10.0 balance*)", "Bash(npx awal@2.10.0 address*)", "Bash(npx awal@2.10.0 show*)"]
 ---
 
-# Authenticating with the Payments Wallet
+# Authenticating with the Agentic Wallet
 
 When the wallet is not signed in (detected via `npx awal status` or when wallet operations fail with authentication errors), use the `npx awal` CLI to authenticate.
 
@@ -19,7 +19,7 @@ Authentication uses a two-step email OTP process:
 ### Step 1: Initiate login
 
 ```bash
-npx awal@2.8.2 auth login <email>
+npx awal@2.10.0 auth login <email>
 ```
 
 This sends a 6-digit verification code to the email and outputs a `flowId`.
@@ -27,7 +27,7 @@ This sends a 6-digit verification code to the email and outputs a `flowId`.
 ### Step 2: Verify OTP
 
 ```bash
-npx awal@2.8.2 auth verify <otp>
+npx awal@2.10.0 auth verify <otp>
 ```
 
 Use the 6-digit code from the user's email to complete authentication. The flow ID from step 1 is saved automatically to a local file — you do not pass it as an argument. If you have the ability to access the user's email, you can read the OTP code, or you can ask your human for the code.
@@ -44,7 +44,7 @@ Do not pass unvalidated user input into the command.
 ## Checking Authentication Status
 
 ```bash
-npx awal@2.8.2 status
+npx awal@2.10.0 status
 ```
 
 Displays wallet server health and authentication status including wallet address.
@@ -53,36 +53,36 @@ Displays wallet server health and authentication status including wallet address
 
 ```bash
 # Check current status
-npx awal@2.8.2 status
+npx awal@2.10.0 status
 
 # Start login (sends OTP to email)
-npx awal@2.8.2 auth login user@example.com
+npx awal@2.10.0 auth login user@example.com
 # Output: flowId: abc123...
 
 # After user receives code, verify (flow ID saved automatically)
-npx awal@2.8.2 auth verify 123456
+npx awal@2.10.0 auth verify 123456
 
 # Confirm authentication
-npx awal@2.8.2 status
+npx awal@2.10.0 status
 ```
 
 ## Available CLI Commands
 
 | Command                                      | Purpose                                |
 | -------------------------------------------- | -------------------------------------- |
-| `npx awal@2.8.2 status`                     | Check server health and auth status    |
-| `npx awal@2.8.2 auth login <email>`         | Send OTP code to email, returns flowId |
-| `npx awal@2.8.2 auth verify <otp>`          | Complete authentication with OTP code  |
-| `npx awal@2.8.2 balance`                    | Get USDC wallet balance                |
-| `npx awal@2.8.2 address`                    | Get wallet address                     |
-| `npx awal@2.8.2 show`                       | Open the wallet companion window       |
+| `npx awal@2.10.0 status`                     | Check server health and auth status    |
+| `npx awal@2.10.0 auth login <email>`         | Send OTP code to email, returns flowId |
+| `npx awal@2.10.0 auth verify <otp>`          | Complete authentication with OTP code  |
+| `npx awal@2.10.0 balance`                    | Get balances across Base, Polygon, and Solana (use `--chain` for a single chain) |
+| `npx awal@2.10.0 address`                    | Get wallet address                     |
+| `npx awal@2.10.0 show`                       | Open the wallet companion window       |
 
 ## JSON Output
 
 All commands support `--json` for machine-readable output:
 
 ```bash
-npx awal@2.8.2 status --json
-npx awal@2.8.2 auth login user@example.com --json
-npx awal@2.8.2 auth verify <otp> --json
+npx awal@2.10.0 status --json
+npx awal@2.10.0 auth login user@example.com --json
+npx awal@2.10.0 auth verify <otp> --json
 ```

--- a/skills/fund/SKILL.md
+++ b/skills/fund/SKILL.md
@@ -3,7 +3,7 @@ name: fund
 description: Add money to the wallet. Use when you or the user want to fund, deposit, top up, load, buy USDC, add funds, onramp, or get USDC. Also use when the wallet has insufficient balance for a send or trade operation, or when someone asks "how do I get USDC?"
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@2.8.2 status*)", "Bash(npx awal@2.8.2 show*)", "Bash(npx awal@2.8.2 address*)", "Bash(npx awal@2.8.2 balance*)"]
+allowed-tools: ["Bash(npx awal@2.10.0 status*)", "Bash(npx awal@2.10.0 show*)", "Bash(npx awal@2.10.0 address*)", "Bash(npx awal@2.10.0 balance*)"]
 ---
 
 # Funding the Wallet
@@ -13,7 +13,7 @@ Use the wallet companion app to fund the wallet with USDC via Coinbase Onramp. T
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@2.8.2 status
+npx awal@2.10.0 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,7 +21,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Opening the Funding Interface
 
 ```bash
-npx awal@2.8.2 show
+npx awal@2.10.0 show
 ```
 
 This opens the wallet companion window where users can:
@@ -44,17 +44,17 @@ This opens the wallet companion window where users can:
 You can also ask your human to send usdc on Base to your wallet address. You can find your wallet address buy running the following:
 
 ```bash
-npx awal@2.8.2 address
+npx awal@2.10.0 address
 ```
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.8.2 status` to check)
+- Must be authenticated (`npx awal@2.10.0 status` to check)
 - Coinbase Onramp is available in supported regions (US, etc.)
 
 ## Flow
 
-1. Run `npx awal@2.8.2 show` to open the wallet UI
+1. Run `npx awal@2.10.0 show` to open the wallet UI
 2. Instruct the user to click the Fund button
 3. User selects amount and payment method in the UI
 4. User completes payment through Coinbase Pay (opens in browser)
@@ -64,7 +64,7 @@ npx awal@2.8.2 address
 
 ```bash
 # Check updated balance
-npx awal@2.8.2 balance
+npx awal@2.10.0 balance
 ```
 
 ## Notes

--- a/skills/monetize-service/SKILL.md
+++ b/skills/monetize-service/SKILL.md
@@ -3,7 +3,7 @@ name: monetize-service
 description: Build and deploy a paid API that other agents can pay to use via x402. Use when you or the user want to monetize an API, make money, earn money, offer a service, sell a service to other agents, charge for endpoints, create a paid endpoint, or set up a paid service. Covers "make money by offering an endpoint", "sell a service", "monetize your data", "create a paid API".
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@2.8.2 status*)", "Bash(npx awal@2.8.2 address*)", "Bash(npx awal@2.8.2 x402 details *)", "Bash(npx awal@2.8.2 x402 pay *)", "Bash(npm *)", "Bash(node *)", "Bash(curl *)", "Bash(mkdir *)"]
+allowed-tools: ["Bash(npx awal@2.10.0 status*)", "Bash(npx awal@2.10.0 address*)", "Bash(npx awal@2.10.0 x402 details *)", "Bash(npx awal@2.10.0 x402 pay *)", "Bash(npm *)", "Bash(node *)", "Bash(curl *)", "Bash(mkdir *)"]
 ---
 
 # Build an x402 Payment Server
@@ -17,7 +17,7 @@ x402 is an HTTP-native payment protocol. When a client hits a protected endpoint
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@2.8.2 status
+npx awal@2.10.0 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -27,7 +27,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 Run this to get the wallet address that will receive payments:
 
 ```bash
-npx awal@2.8.2 address
+npx awal@2.10.0 address
 ```
 
 Use this address as the `payTo` value.
@@ -380,10 +380,10 @@ Once the server is running, use the `pay-for-service` skill to test payments:
 
 ```bash
 # Check the endpoint's payment requirements
-npx awal@2.8.2 x402 details http://localhost:3000/api/example
+npx awal@2.10.0 x402 details http://localhost:3000/api/example
 
 # Make a paid request
-npx awal@2.8.2 x402 pay http://localhost:3000/api/example
+npx awal@2.10.0 x402 pay http://localhost:3000/api/example
 ```
 
 ## Pricing Guidelines
@@ -397,11 +397,11 @@ npx awal@2.8.2 x402 pay http://localhost:3000/api/example
 
 ## Checklist
 
-- [ ] Get wallet address with `npx awal@2.8.2 address`
+- [ ] Get wallet address with `npx awal@2.10.0 address`
 - [ ] Install `express`, `@x402/express`, `@x402/core`, `@x402/evm`, and `@x402/extensions`
 - [ ] Create `x402ResourceServer` with facilitator client and register `ExactEvmScheme` for `eip155:8453`
 - [ ] Define routes with prices, descriptions, and discovery extensions (Bazaar auto-registers when routes declare it)
 - [ ] Register payment middleware before protected routes
 - [ ] Keep health/status endpoints before payment middleware
-- [ ] Test with `curl` (should get 402) and `npx awal@2.8.2 x402 pay` (should get 200)
+- [ ] Test with `curl` (should get 402) and `npx awal@2.10.0 x402 pay` (should get 200)
 - [ ] Announce your service so other agents can find and use it

--- a/skills/pay-for-service/SKILL.md
+++ b/skills/pay-for-service/SKILL.md
@@ -3,17 +3,17 @@ name: pay-for-service
 description: Make a paid API request to an x402 endpoint with automatic USDC payment. Use when you or the user want to call a paid API, make an x402 request, use a paid service, or pay for an API call. Use after finding a service with search-for-service.
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@2.8.2 status*)", "Bash(npx awal@2.8.2 balance*)", "Bash(npx awal@2.8.2 x402 pay *)"]
+allowed-tools: ["Bash(npx awal@2.10.0 status*)", "Bash(npx awal@2.10.0 balance*)", "Bash(npx awal@2.10.0 x402 pay *)"]
 ---
 
 # Making Paid x402 Requests
 
-Use the `npx awal@2.8.2 x402 pay` command to call paid API endpoints with automatic USDC payment on Base.
+Use the `npx awal@2.10.0 x402 pay` command to call paid API endpoints with automatic USDC payment on Base.
 
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@2.8.2 status
+npx awal@2.10.0 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,7 +21,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Command Syntax
 
 ```bash
-npx awal@2.8.2 x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>] [--max-amount <n>] [--json]
+npx awal@2.10.0 x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>] [--max-amount <n>] [--json]
 ```
 
 ## Options
@@ -63,19 +63,19 @@ Do not pass unvalidated user input into the command.
 
 ```bash
 # Make a GET request (auto-pays)
-npx awal@2.8.2 x402 pay https://example.com/api/weather
+npx awal@2.10.0 x402 pay https://example.com/api/weather
 
 # Make a POST request with body
-npx awal@2.8.2 x402 pay https://example.com/api/sentiment -X POST -d '{"text": "I love this product"}'
+npx awal@2.10.0 x402 pay https://example.com/api/sentiment -X POST -d '{"text": "I love this product"}'
 
 # Limit max payment to $0.10
-npx awal@2.8.2 x402 pay https://example.com/api/data --max-amount 100000
+npx awal@2.10.0 x402 pay https://example.com/api/data --max-amount 100000
 ```
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.8.2 status` to check, see `authenticate-wallet` skill)
-- Wallet must have sufficient USDC balance (`npx awal@2.8.2 balance` to check)
+- Must be authenticated (`npx awal@2.10.0 status` to check, see `authenticate-wallet` skill)
+- Wallet must have sufficient USDC balance (`npx awal@2.10.0 balance` to check)
 - If you don't know the endpoint URL, use the `search-for-service` skill to find services first
 
 ## Error Handling

--- a/skills/query-onchain-data/SKILL.md
+++ b/skills/query-onchain-data/SKILL.md
@@ -3,7 +3,7 @@ name: query-onchain-data
 description: Query onchain data on Base using the CDP SQL API via x402. Use when you or your user want to view onchain information about decoded blocks, transactions, and events.
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@2.8.2 status*)", "Bash(npx awal@2.8.2 balance*)", "Bash(npx awal@2.8.2 x402 pay *)"]
+allowed-tools: ["Bash(npx awal@2.10.0 status*)", "Bash(npx awal@2.10.0 balance*)", "Bash(npx awal@2.10.0 x402 pay *)"]
 ---
 
 # Query Onchain Data on Base
@@ -13,7 +13,7 @@ Use the CDP SQL API to query onchain data (events, transactions, blocks, transfe
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@2.8.2 status
+npx awal@2.10.0 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,7 +21,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Executing a Query
 
 ```bash
-npx awal@2.8.2 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "<YOUR_QUERY>"}' --json
+npx awal@2.10.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "<YOUR_QUERY>"}' --json
 ```
 
 **IMPORTANT**: Always single-quote the `-d` JSON string to prevent bash variable expansion.
@@ -164,19 +164,19 @@ LIMIT 10
 ### Get transactions from a specific address
 
 ```bash
-npx awal@2.8.2 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT transaction_hash, to_address, value, gas, timestamp FROM base.transactions WHERE from_address = lower('\''0xYOUR_ADDRESS'\'') AND timestamp >= now() - INTERVAL 1 DAY LIMIT 10"}' --json
+npx awal@2.10.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT transaction_hash, to_address, value, gas, timestamp FROM base.transactions WHERE from_address = lower('\''0xYOUR_ADDRESS'\'') AND timestamp >= now() - INTERVAL 1 DAY LIMIT 10"}' --json
 ```
 
 ### Count events by type for a contract in the last hour
 
 ```bash
-npx awal@2.8.2 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT event_signature, count(*) as cnt FROM base.events WHERE address = lower('\''0xCONTRACT_ADDRESS'\'') AND block_timestamp >= now() - INTERVAL 1 HOUR GROUP BY event_signature ORDER BY cnt DESC LIMIT 20"}' --json
+npx awal@2.10.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT event_signature, count(*) as cnt FROM base.events WHERE address = lower('\''0xCONTRACT_ADDRESS'\'') AND block_timestamp >= now() - INTERVAL 1 HOUR GROUP BY event_signature ORDER BY cnt DESC LIMIT 20"}' --json
 ```
 
 ### Get latest block info
 
 ```bash
-npx awal@2.8.2 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, timestamp, transaction_count, gas_used FROM base.blocks ORDER BY block_number DESC LIMIT 1"}' --json
+npx awal@2.10.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, timestamp, transaction_count, gas_used FROM base.blocks ORDER BY block_number DESC LIMIT 1"}' --json
 ```
 
 ## Common Contract Addresses (Base)
@@ -198,8 +198,8 @@ npx awal@2.8.2 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.8.2 status` to check, see `authenticate-wallet` skill)
-- Wallet must have sufficient USDC balance (`npx awal@2.8.2 balance` to check)
+- Must be authenticated (`npx awal@2.10.0 status` to check, see `authenticate-wallet` skill)
+- Wallet must have sufficient USDC balance (`npx awal@2.10.0 balance` to check)
 - Each query costs $0.10 (100000 USDC atomic units)
 
 ## Error Handling

--- a/skills/search-for-service/SKILL.md
+++ b/skills/search-for-service/SKILL.md
@@ -3,12 +3,12 @@ name: search-for-service
 description: Search and browse the x402 bazaar marketplace for paid API services. Use when you or the user want to find available services, see what's available, discover APIs, or need an external service to accomplish a task. Also use as a fallback when no other skill clearly matches — search the bazaar to see if a paid service exists. Covers "what can I do?", "find me an API for...", "what services are available?", "search for...", "browse the bazaar".
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@2.8.2 x402 bazaar *)", "Bash(npx awal@2.8.2 x402 details *)"]
+allowed-tools: ["Bash(npx awal@2.10.0 x402 bazaar *)", "Bash(npx awal@2.10.0 x402 details *)"]
 ---
 
 # Searching the x402 Bazaar
 
-Use the `npx awal@2.8.2 x402` commands to discover and inspect paid API endpoints available on the x402 bazaar marketplace. No authentication or balance is required for searching.
+Use the `npx awal@2.10.0 x402` commands to discover and inspect paid API endpoints available on the x402 bazaar marketplace. No authentication or balance is required for searching.
 
 ## Commands
 
@@ -17,7 +17,7 @@ Use the `npx awal@2.8.2 x402` commands to discover and inspect paid API endpoint
 Find paid services by keyword using CDP's vector search:
 
 ```bash
-npx awal@2.8.2 x402 bazaar search <query> [-k <n>] [--network <network>] [--scheme <scheme>] [--max-price <price>] [--json]
+npx awal@2.10.0 x402 bazaar search <query> [-k <n>] [--network <network>] [--scheme <scheme>] [--max-price <price>] [--json]
 ```
 
 | Option                  | Description                                                              |
@@ -36,7 +36,7 @@ npx awal@2.8.2 x402 bazaar search <query> [-k <n>] [--network <network>] [--sche
 Browse all available resources:
 
 ```bash
-npx awal@2.8.2 x402 bazaar list [--network <network>] [--full] [--refresh] [--json]
+npx awal@2.10.0 x402 bazaar list [--network <network>] [--full] [--refresh] [--json]
 ```
 
 | Option             | Description                                                          |
@@ -51,7 +51,7 @@ npx awal@2.8.2 x402 bazaar list [--network <network>] [--full] [--refresh] [--js
 Inspect an endpoint's x402 payment requirements without paying:
 
 ```bash
-npx awal@2.8.2 x402 details <url> [--json]
+npx awal@2.10.0 x402 details <url> [--json]
 ```
 
 Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying each until it gets a 402 response, then displays price, accepted payment schemes, network, and input/output schemas.
@@ -60,16 +60,16 @@ Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying e
 
 ```bash
 # Search for weather-related paid APIs
-npx awal@2.8.2 x402 bazaar search "weather"
+npx awal@2.10.0 x402 bazaar search "weather"
 
 # Search with more results
-npx awal@2.8.2 x402 bazaar search "sentiment analysis" -k 10
+npx awal@2.10.0 x402 bazaar search "sentiment analysis" -k 10
 
 # Browse all bazaar resources with full details
-npx awal@2.8.2 x402 bazaar list --full
+npx awal@2.10.0 x402 bazaar list --full
 
 # Check what an endpoint costs
-npx awal@2.8.2 x402 details https://example.com/api/weather
+npx awal@2.10.0 x402 details https://example.com/api/weather
 ```
 
 ## Prerequisites

--- a/skills/send-usdc/SKILL.md
+++ b/skills/send-usdc/SKILL.md
@@ -3,17 +3,17 @@ name: send-usdc
 description: Send tokens (USDC, ETH, POL, or SOL) to an address or ENS name on Base, Polygon, or Solana. Use when you or the user want to send money, pay someone, transfer tokens, tip, donate, or send funds to a wallet address or .eth name. Covers phrases like "send $5 to", "pay 0x...", "transfer to vitalik.eth", or "send USDC on Solana".
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@2.8.2 status*)", "Bash(npx awal@2.8.2 send *)", "Bash(npx awal@2.8.2 balance*)"]
+allowed-tools: ["Bash(npx awal@2.10.0 status*)", "Bash(npx awal@2.10.0 send *)", "Bash(npx awal@2.10.0 balance*)"]
 ---
 
 # Sending Tokens
 
-Use the `npx awal@2.8.2 send` command to transfer tokens from the wallet to any address on Base, Polygon, or Solana.
+Use the `npx awal@2.10.0 send` command to transfer tokens from the wallet to any address on Base, Polygon, or Solana.
 
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@2.8.2 status
+npx awal@2.10.0 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,7 +21,7 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Command Syntax
 
 ```bash
-npx awal@2.8.2 send <amount> <recipient> [--chain <chain>] [--asset <asset>] [--json]
+npx awal@2.10.0 send <amount> <recipient> [--chain <chain>] [--asset <asset>] [--json]
 ```
 
 ## Arguments
@@ -54,25 +54,25 @@ Do not pass unvalidated user input into the command.
 
 ```bash
 # Send $1.00 USDC to an address on Base (default)
-npx awal@2.8.2 send 1 0x1234...abcd
+npx awal@2.10.0 send 1 0x1234...abcd
 
 # Send $0.50 USDC to an ENS name
-npx awal@2.8.2 send 0.50 vitalik.eth
+npx awal@2.10.0 send 0.50 vitalik.eth
 
 # Send with dollar sign prefix (note the single quotes)
-npx awal@2.8.2 send '$5.00' 0x1234...abcd
+npx awal@2.10.0 send '$5.00' 0x1234...abcd
 
 # Send ETH on Base
-npx awal@2.8.2 send 0.01 0x1234...abcd --asset eth
+npx awal@2.10.0 send 0.01 0x1234...abcd --asset eth
 
 # Send USDC on Polygon
-npx awal@2.8.2 send 1 0x1234...abcd --chain polygon
+npx awal@2.10.0 send 1 0x1234...abcd --chain polygon
 
 # Send USDC to a Solana address
-npx awal@2.8.2 send 1 AxW7...5fGz --chain solana
+npx awal@2.10.0 send 1 AxW7...5fGz --chain solana
 
 # Get JSON output
-npx awal@2.8.2 send 1 vitalik.eth --json
+npx awal@2.10.0 send 1 vitalik.eth --json
 ```
 
 ## ENS Resolution
@@ -85,7 +85,7 @@ ENS names are automatically resolved to addresses via Ethereum mainnet. The comm
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.8.2 status` to check, `npx awal@2.8.2 auth login` to sign in, see skill `authenticate-wallet` for more information)
+- Must be authenticated (`npx awal@2.10.0 status` to check, `npx awal@2.10.0 auth login` to sign in, see skill `authenticate-wallet` for more information)
 - Wallet must have sufficient USDC balance (`npx awal balance` to check)
 
 ## Error Handling

--- a/skills/trade/SKILL.md
+++ b/skills/trade/SKILL.md
@@ -3,17 +3,17 @@ name: trade
 description: Swap or trade tokens on Base or Polygon. Use when you or the user want to trade, swap, exchange, buy, sell, or convert between tokens like USDC, ETH, and POL. Covers phrases like "buy ETH", "sell ETH for USDC", "convert USDC to ETH", "get some ETH", "buy POL".
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@2.8.2 status*)", "Bash(npx awal@2.8.2 trade *)", "Bash(npx awal@2.8.2 balance*)"]
+allowed-tools: ["Bash(npx awal@2.10.0 status*)", "Bash(npx awal@2.10.0 trade *)", "Bash(npx awal@2.10.0 balance*)"]
 ---
 
 # Trading Tokens
 
-Use the `npx awal@2.8.2 trade` command to swap tokens on Base or Polygon via the CDP Swap API. You must be authenticated to trade.
+Use the `npx awal@2.10.0 trade` command to swap tokens on Base or Polygon via the CDP Swap API. You must be authenticated to trade.
 
 ## Confirm wallet is initialized and authed
 
 ```bash
-npx awal@2.8.2 status
+npx awal@2.10.0 status
 ```
 
 If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
@@ -21,8 +21,10 @@ If the wallet is not authenticated, refer to the `authenticate-wallet` skill.
 ## Command Syntax
 
 ```bash
-npx awal@2.8.2 trade <amount> <from> <to> [options]
+npx awal@2.10.0 trade <amount> <from> <to> [options]
 ```
+
+The command is also available as `npx awal@2.10.0 swap` (alias).
 
 ## Arguments
 
@@ -79,28 +81,28 @@ Do not pass unvalidated user input into the command.
 
 ```bash
 # Swap $1 USDC for ETH (dollar prefix — note the single quotes)
-npx awal@2.8.2 trade '$1' usdc eth
+npx awal@2.10.0 trade '$1' usdc eth
 
 # Swap 0.50 USDC for ETH (decimal format)
-npx awal@2.8.2 trade 0.50 usdc eth
+npx awal@2.10.0 trade 0.50 usdc eth
 
 # Swap 500000 atomic units of USDC for ETH
-npx awal@2.8.2 trade 500000 usdc eth
+npx awal@2.10.0 trade 500000 usdc eth
 
 # Swap 0.01 ETH for USDC
-npx awal@2.8.2 trade 0.01 eth usdc
+npx awal@2.10.0 trade 0.01 eth usdc
 
 # Swap with custom slippage (2%)
-npx awal@2.8.2 trade '$5' usdc eth --slippage 200
+npx awal@2.10.0 trade '$5' usdc eth --slippage 200
 
 # Swap using contract addresses (decimals read from chain)
-npx awal@2.8.2 trade 100 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 0x4200000000000000000000000000000000000006
+npx awal@2.10.0 trade 100 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 0x4200000000000000000000000000000000000006
 
 # Get JSON output
-npx awal@2.8.2 trade '$1' usdc eth --json
+npx awal@2.10.0 trade '$1' usdc eth --json
 
 # Swap USDC for POL on Polygon
-npx awal@2.8.2 trade '$1' usdc pol --chain polygon
+npx awal@2.10.0 trade '$1' usdc pol --chain polygon
 ```
 
 ## Prerequisites

--- a/skills/x402/SKILL.md
+++ b/skills/x402/SKILL.md
@@ -7,7 +7,7 @@ disable-model-invocation: false
 
 # x402 Payment Protocol
 
-Use the `npx awal@2.8.2 x402` commands to discover, inspect, and call paid API endpoints using the X402 payment protocol. Payments are made in USDC on Base.
+Use the `npx awal@2.10.0 x402` commands to discover, inspect, and call paid API endpoints using the X402 payment protocol. Payments are made in USDC on Base.
 
 ## Workflow
 
@@ -24,7 +24,7 @@ The typical x402 workflow is:
 Find paid services by keyword using CDP's vector search:
 
 ```bash
-npx awal@2.8.2 x402 bazaar search <query> [-k <n>] [--network <network>] [--scheme <scheme>] [--max-price <price>] [--json]
+npx awal@2.10.0 x402 bazaar search <query> [-k <n>] [--network <network>] [--scheme <scheme>] [--max-price <price>] [--json]
 ```
 
 | Option                  | Description                                                              |
@@ -43,7 +43,7 @@ npx awal@2.8.2 x402 bazaar search <query> [-k <n>] [--network <network>] [--sche
 Browse all available resources:
 
 ```bash
-npx awal@2.8.2 x402 bazaar list [--network <network>] [--full] [--refresh] [--json]
+npx awal@2.10.0 x402 bazaar list [--network <network>] [--full] [--refresh] [--json]
 ```
 
 | Option             | Description                                                          |
@@ -58,7 +58,7 @@ npx awal@2.8.2 x402 bazaar list [--network <network>] [--full] [--refresh] [--js
 Inspect an endpoint's x402 payment requirements without paying:
 
 ```bash
-npx awal@2.8.2 x402 details <url> [--json]
+npx awal@2.10.0 x402 details <url> [--json]
 ```
 
 Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying each until it gets a 402 response, then displays price, accepted payment schemes, network, and input/output schemas.
@@ -68,7 +68,7 @@ Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying e
 Call an x402 endpoint with automatic USDC payment:
 
 ```bash
-npx awal@2.8.2 x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>] [--max-amount <n>] [--json]
+npx awal@2.10.0 x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>] [--max-amount <n>] [--json]
 ```
 
 | Option                  | Description                                        |
@@ -85,25 +85,25 @@ npx awal@2.8.2 x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>
 
 ```bash
 # Search for weather-related paid APIs
-npx awal@2.8.2 x402 bazaar search "weather"
+npx awal@2.10.0 x402 bazaar search "weather"
 
 # Search with more results
-npx awal@2.8.2 x402 bazaar search "sentiment analysis" -k 10
+npx awal@2.10.0 x402 bazaar search "sentiment analysis" -k 10
 
 # Check what an endpoint costs
-npx awal@2.8.2 x402 details https://example.com/api/weather
+npx awal@2.10.0 x402 details https://example.com/api/weather
 
 # Make a GET request (auto-pays)
-npx awal@2.8.2 x402 pay https://example.com/api/weather
+npx awal@2.10.0 x402 pay https://example.com/api/weather
 
 # Make a POST request with body
-npx awal@2.8.2 x402 pay https://example.com/api/sentiment -X POST -d '{"text": "I love this product"}'
+npx awal@2.10.0 x402 pay https://example.com/api/sentiment -X POST -d '{"text": "I love this product"}'
 
 # Limit max payment to $0.10
-npx awal@2.8.2 x402 pay https://example.com/api/data --max-amount 100000
+npx awal@2.10.0 x402 pay https://example.com/api/data --max-amount 100000
 
 # Browse all bazaar resources with full details
-npx awal@2.8.2 x402 bazaar list --full
+npx awal@2.10.0 x402 bazaar list --full
 ```
 
 ## USDC Amounts
@@ -120,11 +120,11 @@ X402 uses USDC atomic units (6 decimals):
 ## Prerequisites
 
 - **Search/Details**: No authentication needed
-- **Pay**: Must be authenticated (`npx awal@2.8.2 auth login <email>`) with sufficient USDC balance (`npx awal@2.8.2 balance`)
+- **Pay**: Must be authenticated (`npx awal@2.10.0 auth login <email>`) with sufficient USDC balance (`npx awal@2.10.0 balance`)
 
 ## Error Handling
 
-- "Not authenticated" - Run `npx awal@2.8.2 auth login <email>` first
+- "Not authenticated" - Run `npx awal@2.10.0 auth login <email>` first
 - "No X402 payment requirements found" - URL may not be an x402 endpoint
 - "CDP API returned 429" - Rate limited; cached data will be used if available
-- "Insufficient balance" - Fund wallet with USDC (`npx awal@2.8.2 balance` to check)
+- "Insufficient balance" - Fund wallet with USDC (`npx awal@2.10.0 balance` to check)


### PR DESCRIPTION
## Summary

- Bump all SKILL.md `awal` references from `2.8.2` to `2.10.0`
- `authenticate-wallet`: rename the H1 to "Agentic Wallet" and correct the `balance` command row — `awal balance` now defaults to fetching Base, Polygon, and Solana in parallel (use `--chain` for a single chain).
- `trade`: note that the command is also exposed as `npx awal@2.10.0 swap` (alias).