### PR TITLE
chore: bump awal to 2.12.0

### DIFF
--- a/skills/agentic-wallet/SKILL.md
+++ b/skills/agentic-wallet/SKILL.md
@@ -3,7 +3,7 @@ name: agentic-wallet
 description: "Crypto wallet operations via the awal CLI — sign in, check balances, send USDC/ETH/POL/SOL, trade tokens, fund the wallet, and use the x402 payment protocol to discover paid services, pay for API calls, monetize an API, or query onchain data. Use whenever the user mentions signing in, login, authentication, wallet status, balance, address, sending money, paying someone, transferring tokens, ENS names, swapping/trading/converting tokens, funding/topping up/onramp, USDC, ETH, POL, SOL, the x402 bazaar, paid APIs, monetizing an endpoint, or querying onchain data on Base."
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx awal@2.10.0 *)", "Bash(npm *)", "Bash(node *)", "Bash(curl *)", "Bash(mkdir *)"]
+allowed-tools: ["Bash(npx awal@2.12.0 *)", "Bash(npm *)", "Bash(node *)", "Bash(curl *)", "Bash(mkdir *)"]
 ---
 
 # Agentic Wallet
@@ -15,7 +15,7 @@ Operate a crypto wallet through the `awal` CLI. This skill is a router: read the
 Before any wallet operation that requires authentication (everything except x402 search/details), check status:
 
 ```bash
-npx awal@2.10.0 status
+npx awal@2.12.0 status
 ```
 
 If the wallet is not authenticated, read `references/auth.md` and complete sign-in first.
@@ -50,15 +50,15 @@ If no clear match and the user wants an external capability, search the x402 baz
 
 | Command | Purpose |
 | --- | --- |
-| `npx awal@2.10.0 status` | Server health + auth status |
-| `npx awal@2.10.0 address` | Get wallet address |
-| `npx awal@2.10.0 balance` | Get balances across Base, Polygon, Solana (use `--chain` for one chain) |
-| `npx awal@2.10.0 show` | Open the wallet companion window (used for funding) |
-| `npx awal@2.10.0 auth login <email>` | Send OTP code |
-| `npx awal@2.10.0 auth verify <otp>` | Complete sign-in |
-| `npx awal@2.10.0 send <amount> <recipient>` | Send tokens |
-| `npx awal@2.10.0 trade <amount> <from> <to>` | Swap tokens |
-| `npx awal@2.10.0 x402 bazaar search <query>` | Search paid services |
-| `npx awal@2.10.0 x402 bazaar list` | List bazaar resources |
-| `npx awal@2.10.0 x402 details <url>` | Inspect payment requirements |
-| `npx awal@2.10.0 x402 pay <url>` | Pay and call an x402 endpoint |
+| `npx awal@2.12.0 status` | Server health + auth status |
+| `npx awal@2.12.0 address` | Get wallet address |
+| `npx awal@2.12.0 balance` | Get balances across Base, Polygon, Solana (use `--chain` for one chain) |
+| `npx awal@2.12.0 show` | Open the wallet companion window (used for funding) |
+| `npx awal@2.12.0 auth login <email>` | Send OTP code |
+| `npx awal@2.12.0 auth verify <otp>` | Complete sign-in |
+| `npx awal@2.12.0 send <amount> <recipient>` | Send tokens |
+| `npx awal@2.12.0 trade <amount> <from> <to>` | Swap tokens |
+| `npx awal@2.12.0 x402 bazaar search <query>` | Search paid services |
+| `npx awal@2.12.0 x402 bazaar list` | List bazaar resources |
+| `npx awal@2.12.0 x402 details <url>` | Inspect payment requirements |
+| `npx awal@2.12.0 x402 pay <url>` | Pay and call an x402 endpoint |

--- a/skills/agentic-wallet/references/auth.md
+++ b/skills/agentic-wallet/references/auth.md
@@ -1,6 +1,6 @@
 # Authenticating with the Agentic Wallet
 
-When the wallet is not signed in (detected via `npx awal@2.10.0 status` or when wallet operations fail with authentication errors), use the `npx awal` CLI to authenticate.
+When the wallet is not signed in (detected via `npx awal@2.12.0 status` or when wallet operations fail with authentication errors), use the `npx awal` CLI to authenticate.
 
 If you have access to email, you can authenticate the wallet yourself, otherwise you'll need to ask your human to give you an email address and to tell you the OTP code they receive.
 
@@ -11,7 +11,7 @@ Authentication uses a two-step email OTP process:
 ### Step 1: Initiate login
 
 ```bash
-npx awal@2.10.0 auth login <email>
+npx awal@2.12.0 auth login <email>
 ```
 
 This sends a 6-digit verification code to the email. The `flowId` is saved automatically; it is only printed to stdout when `--json` is passed.
@@ -19,7 +19,7 @@ This sends a 6-digit verification code to the email. The `flowId` is saved autom
 ### Step 2: Verify OTP
 
 ```bash
-npx awal@2.10.0 auth verify <otp>
+npx awal@2.12.0 auth verify <otp>
 ```
 
 Use the 6-digit code from the user's email to complete authentication. The flow ID from step 1 is saved automatically to a local file — you do not pass it as an argument. If you have the ability to access the user's email, you can read the OTP code, or you can ask your human for the code.
@@ -36,7 +36,7 @@ Do not pass unvalidated user input into the command.
 ## Checking Authentication Status
 
 ```bash
-npx awal@2.10.0 status
+npx awal@2.12.0 status
 ```
 
 Displays wallet server health and authentication status including wallet address.
@@ -45,17 +45,17 @@ Displays wallet server health and authentication status including wallet address
 
 ```bash
 # Check current status
-npx awal@2.10.0 status
+npx awal@2.12.0 status
 
 # Start login (sends OTP to email)
-npx awal@2.10.0 auth login user@example.com
+npx awal@2.12.0 auth login user@example.com
 # Output: "Verification code sent!" (flowId only printed with --json)
 
 # After user receives code, verify (flow ID saved automatically)
-npx awal@2.10.0 auth verify 123456
+npx awal@2.12.0 auth verify 123456
 
 # Confirm authentication
-npx awal@2.10.0 status
+npx awal@2.12.0 status
 ```
 
 ## Signing Out
@@ -65,37 +65,37 @@ There is **no `awal auth logout` CLI command** today. The agent cannot log the u
 When the user asks to log out, sign out, disconnect, or switch accounts:
 
 ```bash
-npx awal@2.10.0 show
+npx awal@2.12.0 show
 ```
 
 Then guide the user through the UI:
 
-1. Run `npx awal@2.10.0 show` to bring the wallet companion window to the foreground.
+1. Run `npx awal@2.12.0 show` to bring the wallet companion window to the foreground.
 2. Tell the user to open the wallet menu (settings / profile area in the companion window).
 3. Have the user click **Sign out** (or **Log out**) inside that window.
-4. Confirm the result with `npx awal@2.10.0 status` — once logged out, the status will report the wallet as not authenticated.
+4. Confirm the result with `npx awal@2.12.0 status` — once logged out, the status will report the wallet as not authenticated.
 
-After sign-out, the locally cached `flowId` is invalidated. To sign back in, restart the flow with `npx awal@2.10.0 auth login <email>`.
+After sign-out, the locally cached `flowId` is invalidated. To sign back in, restart the flow with `npx awal@2.12.0 auth login <email>`.
 
-If `npx awal@2.10.0 show` does not bring up a window (e.g. running in a non-graphical environment), let the user know that logout requires the wallet companion UI and is not currently scriptable.
+If `npx awal@2.12.0 show` does not bring up a window (e.g. running in a non-graphical environment), let the user know that logout requires the wallet companion UI and is not currently scriptable.
 
 ## Available CLI Commands
 
 | Command                              | Purpose                                                                          |
 | ------------------------------------ | -------------------------------------------------------------------------------- |
-| `npx awal@2.10.0 status`             | Check server health and auth status                                              |
-| `npx awal@2.10.0 auth login <email>` | Send OTP code to email, returns flowId                                           |
-| `npx awal@2.10.0 auth verify <otp>`  | Complete authentication with OTP code                                            |
-| `npx awal@2.10.0 balance`            | Get balances across Base, Polygon, and Solana (use `--chain` for a single chain) |
-| `npx awal@2.10.0 address`            | Get wallet address                                                               |
-| `npx awal@2.10.0 show`               | Open the wallet companion window (also used for sign-out via the UI)             |
+| `npx awal@2.12.0 status`             | Check server health and auth status                                              |
+| `npx awal@2.12.0 auth login <email>` | Send OTP code to email, returns flowId                                           |
+| `npx awal@2.12.0 auth verify <otp>`  | Complete authentication with OTP code                                            |
+| `npx awal@2.12.0 balance`            | Get balances across Base, Polygon, and Solana (use `--chain` for a single chain) |
+| `npx awal@2.12.0 address`            | Get wallet address                                                               |
+| `npx awal@2.12.0 show`               | Open the wallet companion window (also used for sign-out via the UI)             |
 
 ## JSON Output
 
 All commands support `--json` for machine-readable output:
 
 ```bash
-npx awal@2.10.0 status --json
-npx awal@2.10.0 auth login user@example.com --json
-npx awal@2.10.0 auth verify <otp> --json
+npx awal@2.12.0 status --json
+npx awal@2.12.0 auth login user@example.com --json
+npx awal@2.12.0 auth verify <otp> --json
 ```

--- a/skills/agentic-wallet/references/balance.md
+++ b/skills/agentic-wallet/references/balance.md
@@ -1,13 +1,13 @@
 # Checking Wallet Balances
 
-Use the `npx awal@2.10.0 balance` command to fetch token balances across chains. By default it returns balances for **USDC + the native gas token** on **Base, Polygon, and Solana** in a single call.
+Use the `npx awal@2.12.0 balance` command to fetch token balances across chains. By default it returns balances for **USDC + the native gas token** on **Base, Polygon, and Solana** in a single call.
 
 If the wallet is not authenticated, see `references/auth.md`. The CLI reads the address from the local wallet session — you do not pass an address argument.
 
 ## Command Syntax
 
 ```bash
-npx awal@2.10.0 balance [--chain <chain>] [--asset <asset>] [--json]
+npx awal@2.12.0 balance [--chain <chain>] [--asset <asset>] [--json]
 ```
 
 ## Options
@@ -57,26 +57,26 @@ Token decimals: USDC = 6, ETH = 18, POL = 18, SOL = 9.
 
 ```bash
 # Default — all chains, all native assets + USDC
-npx awal@2.10.0 balance
+npx awal@2.12.0 balance
 
 # One chain only (mainnet Base)
-npx awal@2.10.0 balance --chain base
+npx awal@2.12.0 balance --chain base
 
 # Testnet balance (Base Sepolia)
-npx awal@2.10.0 balance --chain base-sepolia
+npx awal@2.12.0 balance --chain base-sepolia
 
 # Just USDC, across every chain
-npx awal@2.10.0 balance --asset usdc
+npx awal@2.12.0 balance --asset usdc
 
 # Just ETH on Base
-npx awal@2.10.0 balance --chain base --asset eth
+npx awal@2.12.0 balance --chain base --asset eth
 
 # Solana SOL balance
-npx awal@2.10.0 balance --chain solana --asset sol
+npx awal@2.12.0 balance --chain solana --asset sol
 
 # Machine-readable JSON
-npx awal@2.10.0 balance --json
-npx awal@2.10.0 balance --chain base --asset usdc --json
+npx awal@2.12.0 balance --json
+npx awal@2.12.0 balance --chain base --asset usdc --json
 ```
 
 ## Output Format
@@ -179,7 +179,7 @@ When passing `--max-amount` to `x402 pay`, or atomic amounts to `send`/`trade`, 
 
 ```bash
 # Check whether the wallet has enough USDC on Base before paying / sending
-npx awal@2.10.0 balance --chain base --asset usdc --json
+npx awal@2.12.0 balance --chain base --asset usdc --json
 ```
 
 If `formatted` is below the required amount, see `references/fund.md` to top up.
@@ -187,14 +187,14 @@ If `formatted` is below the required amount, see `references/fund.md` to top up.
 ### Check spendable USDC across all chains
 
 ```bash
-npx awal@2.10.0 balance --asset usdc --json
+npx awal@2.12.0 balance --asset usdc --json
 ```
 
 ### Confirm gas (ETH on Base, POL on Polygon) is available before a swap
 
 ```bash
-npx awal@2.10.0 balance --chain base --asset eth --json
-npx awal@2.10.0 balance --chain polygon --asset pol --json
+npx awal@2.12.0 balance --chain base --asset eth --json
+npx awal@2.12.0 balance --chain polygon --asset pol --json
 ```
 
 ETH/POL are only required when the swap or send is on that chain — most USDC sends/trades on Base are gasless via paymaster, but trades may require small ETH for gas.
@@ -205,13 +205,13 @@ If you only need the address (not balances), prefer the cheaper `address` comman
 
 ```bash
 # Human-readable, all chains
-npx awal@2.10.0 address
+npx awal@2.12.0 address
 
 # Machine-readable, all chains
-npx awal@2.10.0 address --json
+npx awal@2.12.0 address --json
 
 # Single-chain (returns just the bare address string with no label)
-npx awal@2.10.0 address --chain base
+npx awal@2.12.0 address --chain base
 ```
 
 **Output shapes — important:**
@@ -224,11 +224,11 @@ npx awal@2.10.0 address --chain base
 
   If you need separate EVM and Solana addresses programmatically, prefer `balance --json` and read the per-chain `address` field, or split the string on the newline and the `EVM (...): ` / `Solana: ` prefixes.
 
-- `address --chain <chain>` prints just the raw address for that chain with no label or JSON wrapper, even without `--json`. Useful for shell substitution: `ADDR=$(npx awal@2.10.0 address --chain base)`.
+- `address --chain <chain>` prints just the raw address for that chain with no label or JSON wrapper, even without `--json`. Useful for shell substitution: `ADDR=$(npx awal@2.12.0 address --chain base)`.
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.10.0 status` to check; see `references/auth.md`).
+- Must be authenticated (`npx awal@2.12.0 status` to check; see `references/auth.md`).
 - Server reachable — `balance` calls the local wallet companion which talks to CDP.
 
 ## Error Handling
@@ -236,7 +236,7 @@ npx awal@2.10.0 address --chain base
 | Symptom                                                                       | Resolution                                                                                                                                                                |
 | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Not authenticated` / `not signed in`                                         | Run the sign-in flow in `references/auth.md`.                                                                                                                             |
-| Hangs on `Fetching balances...`                                               | The wallet companion may be unreachable. Run `npx awal@2.10.0 status` to verify server health.                                                                            |
+| Hangs on `Fetching balances...`                                               | The wallet companion may be unreachable. Run `npx awal@2.12.0 status` to verify server health.                                                                            |
 | `balances` object empty for a chain                                           | The asset filter has no match on that chain (e.g. `--asset eth --chain polygon`). Drop the filter or use a supported asset.                                               |
 | Inline `Unsupported Solana asset: "ETH"` (or similar) printed in output       | You passed an incompatible `--asset` for that chain (e.g. `--asset eth --chain solana`). Use a supported asset for the chain — see "Asset / Chain Compatibility" above.   |
 | Non-zero `POL` on Base or `SOL` on Base                                       | CLI bug: it's reporting the ETH balance under the wrong symbol. Re-query with the correct chain (`--asset pol --chain polygon`, `--asset sol --chain solana`).            |

--- a/skills/agentic-wallet/references/fund.md
+++ b/skills/agentic-wallet/references/fund.md
@@ -7,7 +7,7 @@ If the wallet is not authenticated, see `references/auth.md`.
 ## Opening the Funding Interface
 
 ```bash
-npx awal@2.10.0 show
+npx awal@2.12.0 show
 ```
 
 This opens the wallet companion window where users can:
@@ -30,17 +30,17 @@ This opens the wallet companion window where users can:
 You can also ask your human to send USDC on Base to your wallet address. Get the address with:
 
 ```bash
-npx awal@2.10.0 address
+npx awal@2.12.0 address
 ```
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.10.0 status` to check)
+- Must be authenticated (`npx awal@2.12.0 status` to check)
 - Coinbase Onramp is available in supported regions (US, etc.)
 
 ## Flow
 
-1. Run `npx awal@2.10.0 show` to open the wallet UI
+1. Run `npx awal@2.12.0 show` to open the wallet UI
 2. Instruct the user to click the Fund button
 3. User selects amount and payment method in the UI
 4. User completes payment through Coinbase Pay (opens in browser)
@@ -50,7 +50,7 @@ npx awal@2.10.0 address
 
 ```bash
 # Check updated balance
-npx awal@2.10.0 balance
+npx awal@2.12.0 balance
 ```
 
 ## Notes

--- a/skills/agentic-wallet/references/query-onchain.md
+++ b/skills/agentic-wallet/references/query-onchain.md
@@ -7,7 +7,7 @@ If the wallet is not authenticated, see `references/auth.md`.
 ## Executing a Query
 
 ```bash
-npx awal@2.10.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "<YOUR_QUERY>"}' --json
+npx awal@2.12.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "<YOUR_QUERY>"}' --json
 ```
 
 **IMPORTANT**: Always single-quote the `-d` JSON string to prevent bash variable expansion.
@@ -150,19 +150,19 @@ LIMIT 10
 ### Get transactions from a specific address
 
 ```bash
-npx awal@2.10.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT transaction_hash, to_address, value, gas, timestamp FROM base.transactions WHERE from_address = lower('\''0xYOUR_ADDRESS'\'') AND timestamp >= now() - INTERVAL 1 DAY LIMIT 10"}' --json
+npx awal@2.12.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT transaction_hash, to_address, value, gas, timestamp FROM base.transactions WHERE from_address = lower('\''0xYOUR_ADDRESS'\'') AND timestamp >= now() - INTERVAL 1 DAY LIMIT 10"}' --json
 ```
 
 ### Count events by type for a contract in the last hour
 
 ```bash
-npx awal@2.10.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT event_signature, count(*) as cnt FROM base.events WHERE address = lower('\''0xCONTRACT_ADDRESS'\'') AND block_timestamp >= now() - INTERVAL 1 HOUR GROUP BY event_signature ORDER BY cnt DESC LIMIT 20"}' --json
+npx awal@2.12.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT event_signature, count(*) as cnt FROM base.events WHERE address = lower('\''0xCONTRACT_ADDRESS'\'') AND block_timestamp >= now() - INTERVAL 1 HOUR GROUP BY event_signature ORDER BY cnt DESC LIMIT 20"}' --json
 ```
 
 ### Get latest block info
 
 ```bash
-npx awal@2.10.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, timestamp, transaction_count, gas_used FROM base.blocks ORDER BY block_number DESC LIMIT 1"}' --json
+npx awal@2.12.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/run -X POST -d '{"sql": "SELECT block_number, timestamp, transaction_count, gas_used FROM base.blocks ORDER BY block_number DESC LIMIT 1"}' --json
 ```
 
 ## Common Contract Addresses (Base)
@@ -184,8 +184,8 @@ npx awal@2.10.0 x402 pay https://x402.cdp.coinbase.com/platform/v2/data/query/ru
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.10.0 status` to check; see `references/auth.md`)
-- Wallet must have sufficient USDC balance (`npx awal@2.10.0 balance` to check; see `references/fund.md`)
+- Must be authenticated (`npx awal@2.12.0 status` to check; see `references/auth.md`)
+- Wallet must have sufficient USDC balance (`npx awal@2.12.0 balance` to check; see `references/fund.md`)
 - Each query costs $0.10 (100000 USDC atomic units)
 
 ## Error Handling

--- a/skills/agentic-wallet/references/send-usdc.md
+++ b/skills/agentic-wallet/references/send-usdc.md
@@ -1,13 +1,13 @@
 # Sending Tokens
 
-Use the `npx awal@2.10.0 send` command to transfer tokens from the wallet to any address on Base, Polygon, or Solana.
+Use the `npx awal@2.12.0 send` command to transfer tokens from the wallet to any address on Base, Polygon, or Solana.
 
 If the wallet is not authenticated, see `references/auth.md`.
 
 ## Command Syntax
 
 ```bash
-npx awal@2.10.0 send <amount> <recipient> [--chain <chain>] [--asset <asset>] [--json]
+npx awal@2.12.0 send <amount> <recipient> [--chain <chain>] [--asset <asset>] [--json]
 ```
 
 ## Arguments
@@ -40,25 +40,25 @@ Do not pass unvalidated user input into the command.
 
 ```bash
 # Send $1.00 USDC to an address on Base (default)
-npx awal@2.10.0 send 1 0x1234...abcd
+npx awal@2.12.0 send 1 0x1234...abcd
 
 # Send $0.50 USDC to an ENS name
-npx awal@2.10.0 send 0.50 vitalik.eth
+npx awal@2.12.0 send 0.50 vitalik.eth
 
 # Send with dollar sign prefix (note the single quotes)
-npx awal@2.10.0 send '$5.00' 0x1234...abcd
+npx awal@2.12.0 send '$5.00' 0x1234...abcd
 
 # Send ETH on Base
-npx awal@2.10.0 send 0.01 0x1234...abcd --asset eth
+npx awal@2.12.0 send 0.01 0x1234...abcd --asset eth
 
 # Send USDC on Polygon
-npx awal@2.10.0 send 1 0x1234...abcd --chain polygon
+npx awal@2.12.0 send 1 0x1234...abcd --chain polygon
 
 # Send USDC to a Solana address
-npx awal@2.10.0 send 1 AxW7...5fGz --chain solana
+npx awal@2.12.0 send 1 AxW7...5fGz --chain solana
 
 # Get JSON output
-npx awal@2.10.0 send 1 vitalik.eth --json
+npx awal@2.12.0 send 1 vitalik.eth --json
 ```
 
 ## ENS Resolution
@@ -71,15 +71,15 @@ ENS names are automatically resolved to addresses via Ethereum mainnet. The comm
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.10.0 status` to check; see `references/auth.md`)
-- Wallet must have sufficient balance (`npx awal@2.10.0 balance` to check; see `references/fund.md` to top up)
+- Must be authenticated (`npx awal@2.12.0 status` to check; see `references/auth.md`)
+- Wallet must have sufficient balance (`npx awal@2.12.0 balance` to check; see `references/fund.md` to top up)
 
 ## Error Handling
 
 Common errors:
 
 - "Not authenticated" - See `references/auth.md`
-- "Insufficient balance" - Check balance with `npx awal@2.10.0 balance`; see `references/fund.md`
+- "Insufficient balance" - Check balance with `npx awal@2.12.0 balance`; see `references/fund.md`
 - "Could not resolve ENS name" - Verify the ENS name exists
 - "Invalid recipient" - Must be valid 0x address, ENS name, or Solana Base58 address
 - "SOL only supported on Solana chains" - Use `--chain solana` when sending SOL

--- a/skills/agentic-wallet/references/trade.md
+++ b/skills/agentic-wallet/references/trade.md
@@ -1,16 +1,16 @@
 # Trading Tokens
 
-Use the `npx awal@2.10.0 trade` command to swap tokens on Base or Polygon via the CDP Swap API. You must be authenticated to trade.
+Use the `npx awal@2.12.0 trade` command to swap tokens on Base or Polygon via the CDP Swap API. You must be authenticated to trade.
 
 If the wallet is not authenticated, see `references/auth.md`.
 
 ## Command Syntax
 
 ```bash
-npx awal@2.10.0 trade <amount> <from> <to> [options]
+npx awal@2.12.0 trade <amount> <from> <to> [options]
 ```
 
-The command is also available as `npx awal@2.10.0 swap` (alias).
+The command is also available as `npx awal@2.12.0 swap` (alias).
 
 ## Arguments
 
@@ -67,33 +67,33 @@ Do not pass unvalidated user input into the command.
 
 ```bash
 # Swap $1 USDC for ETH (dollar prefix — note the single quotes)
-npx awal@2.10.0 trade '$1' usdc eth
+npx awal@2.12.0 trade '$1' usdc eth
 
 # Swap 0.50 USDC for ETH (decimal format)
-npx awal@2.10.0 trade 0.50 usdc eth
+npx awal@2.12.0 trade 0.50 usdc eth
 
 # Swap 500000 atomic units of USDC for ETH
-npx awal@2.10.0 trade 500000 usdc eth
+npx awal@2.12.0 trade 500000 usdc eth
 
 # Swap 0.01 ETH for USDC
-npx awal@2.10.0 trade 0.01 eth usdc
+npx awal@2.12.0 trade 0.01 eth usdc
 
 # Swap with custom slippage (2%)
-npx awal@2.10.0 trade '$5' usdc eth --slippage 200
+npx awal@2.12.0 trade '$5' usdc eth --slippage 200
 
 # Swap using contract addresses (decimals read from chain)
-npx awal@2.10.0 trade 100 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 0x4200000000000000000000000000000000000006
+npx awal@2.12.0 trade 100 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 0x4200000000000000000000000000000000000006
 
 # Get JSON output
-npx awal@2.10.0 trade '$1' usdc eth --json
+npx awal@2.12.0 trade '$1' usdc eth --json
 
 # Swap USDC for POL on Polygon
-npx awal@2.10.0 trade '$1' usdc pol --chain polygon
+npx awal@2.12.0 trade '$1' usdc pol --chain polygon
 ```
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.10.0 status` to check; see `references/auth.md`)
+- Must be authenticated (`npx awal@2.12.0 status` to check; see `references/auth.md`)
 - Wallet must have sufficient balance of the source token
 
 ## Error Handling

--- a/skills/agentic-wallet/references/x402-monetize.md
+++ b/skills/agentic-wallet/references/x402-monetize.md
@@ -13,7 +13,7 @@ If the wallet is not authenticated, see `references/auth.md`.
 Run this to get the wallet address that will receive payments:
 
 ```bash
-npx awal@2.10.0 address
+npx awal@2.12.0 address
 ```
 
 Use this address as the `payTo` value.
@@ -366,10 +366,10 @@ Once the server is running, test payments using the commands in `references/x402
 
 ```bash
 # Check the endpoint's payment requirements
-npx awal@2.10.0 x402 details http://localhost:3000/api/example
+npx awal@2.12.0 x402 details http://localhost:3000/api/example
 
 # Make a paid request
-npx awal@2.10.0 x402 pay http://localhost:3000/api/example
+npx awal@2.12.0 x402 pay http://localhost:3000/api/example
 ```
 
 ## Pricing Guidelines
@@ -383,11 +383,11 @@ npx awal@2.10.0 x402 pay http://localhost:3000/api/example
 
 ## Checklist
 
-- [ ] Get wallet address with `npx awal@2.10.0 address`
+- [ ] Get wallet address with `npx awal@2.12.0 address`
 - [ ] Install `express`, `@x402/express`, `@x402/core`, `@x402/evm`, and `@x402/extensions`
 - [ ] Create `x402ResourceServer` with facilitator client and register `ExactEvmScheme` for `eip155:8453`
 - [ ] Define routes with prices, descriptions, and discovery extensions (Bazaar auto-registers when routes declare it)
 - [ ] Register payment middleware before protected routes
 - [ ] Keep health/status endpoints before payment middleware
-- [ ] Test with `curl` (should get 402) and `npx awal@2.10.0 x402 pay` (should get 200)
+- [ ] Test with `curl` (should get 402) and `npx awal@2.12.0 x402 pay` (should get 200)
 - [ ] Announce your service so other agents can find and use it

--- a/skills/agentic-wallet/references/x402-pay.md
+++ b/skills/agentic-wallet/references/x402-pay.md
@@ -1,13 +1,13 @@
 # Making Paid x402 Requests
 
-Use the `npx awal@2.10.0 x402 pay` command to call paid API endpoints with automatic USDC payment on Base.
+Use the `npx awal@2.12.0 x402 pay` command to call paid API endpoints with automatic USDC payment on Base.
 
 If the wallet is not authenticated, see `references/auth.md`.
 
 ## Command Syntax
 
 ```bash
-npx awal@2.10.0 x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>] [--max-amount <n>] [--json]
+npx awal@2.12.0 x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>] [--max-amount <n>] [--json]
 ```
 
 ## Options
@@ -49,19 +49,19 @@ Do not pass unvalidated user input into the command.
 
 ```bash
 # Make a GET request (auto-pays)
-npx awal@2.10.0 x402 pay https://example.com/api/weather
+npx awal@2.12.0 x402 pay https://example.com/api/weather
 
 # Make a POST request with body
-npx awal@2.10.0 x402 pay https://example.com/api/sentiment -X POST -d '{"text": "I love this product"}'
+npx awal@2.12.0 x402 pay https://example.com/api/sentiment -X POST -d '{"text": "I love this product"}'
 
 # Limit max payment to $0.10
-npx awal@2.10.0 x402 pay https://example.com/api/data --max-amount 100000
+npx awal@2.12.0 x402 pay https://example.com/api/data --max-amount 100000
 ```
 
 ## Prerequisites
 
-- Must be authenticated (`npx awal@2.10.0 status` to check; see `references/auth.md`)
-- Wallet must have sufficient USDC balance (`npx awal@2.10.0 balance` to check; see `references/fund.md` to top up)
+- Must be authenticated (`npx awal@2.12.0 status` to check; see `references/auth.md`)
+- Wallet must have sufficient USDC balance (`npx awal@2.12.0 balance` to check; see `references/fund.md` to top up)
 - If you don't know the endpoint URL, see `references/x402-search.md` to find services first
 
 ## Error Handling

--- a/skills/agentic-wallet/references/x402-search.md
+++ b/skills/agentic-wallet/references/x402-search.md
@@ -1,6 +1,6 @@
 # Searching the x402 Bazaar
 
-Use the `npx awal@2.10.0 x402` commands to discover and inspect paid API endpoints available on the x402 bazaar marketplace. **No authentication or balance is required for searching.**
+Use the `npx awal@2.12.0 x402` commands to discover and inspect paid API endpoints available on the x402 bazaar marketplace. **No authentication or balance is required for searching.**
 
 ## Commands
 
@@ -9,7 +9,7 @@ Use the `npx awal@2.10.0 x402` commands to discover and inspect paid API endpoin
 Find paid services by keyword using CDP's vector search:
 
 ```bash
-npx awal@2.10.0 x402 bazaar search <query> [-k <n>] [--network <network>] [--scheme <scheme>] [--max-price <price>] [--json]
+npx awal@2.12.0 x402 bazaar search <query> [-k <n>] [--network <network>] [--scheme <scheme>] [--max-price <price>] [--json]
 ```
 
 | Option                  | Description                                                              |
@@ -28,7 +28,7 @@ npx awal@2.10.0 x402 bazaar search <query> [-k <n>] [--network <network>] [--sch
 Browse all available resources:
 
 ```bash
-npx awal@2.10.0 x402 bazaar list [--network <network>] [--full] [--refresh] [--json]
+npx awal@2.12.0 x402 bazaar list [--network <network>] [--full] [--refresh] [--json]
 ```
 
 | Option             | Description                                                          |
@@ -43,7 +43,7 @@ npx awal@2.10.0 x402 bazaar list [--network <network>] [--full] [--refresh] [--j
 Inspect an endpoint's x402 payment requirements without paying:
 
 ```bash
-npx awal@2.10.0 x402 details <url> [--json]
+npx awal@2.12.0 x402 details <url> [--json]
 ```
 
 Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying each until it gets a 402 response, then displays price, accepted payment schemes, network, and input/output schemas.
@@ -52,16 +52,16 @@ Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying e
 
 ```bash
 # Search for weather-related paid APIs
-npx awal@2.10.0 x402 bazaar search "weather"
+npx awal@2.12.0 x402 bazaar search "weather"
 
 # Search with more results
-npx awal@2.10.0 x402 bazaar search "sentiment analysis" -k 10
+npx awal@2.12.0 x402 bazaar search "sentiment analysis" -k 10
 
 # Browse all bazaar resources with full details
-npx awal@2.10.0 x402 bazaar list --full
+npx awal@2.12.0 x402 bazaar list --full
 
 # Check what an endpoint costs
-npx awal@2.10.0 x402 details https://example.com/api/weather
+npx awal@2.12.0 x402 details https://example.com/api/weather
 ```
 
 ## Next Steps


### PR DESCRIPTION
Updates all skill doc references from `awal@2.10.0` to `awal@2.12.0` (111 references across 10 files) following the [payments-mcp 2.12.0 release](https://coinbase.ghe.com/commerce/payments-mcp/pull/132).