### PR TITLE
fix: correct x402 facilitator URL

### DIFF
--- a/skills/agentic-wallet/references/x402-monetize.md
+++ b/skills/agentic-wallet/references/x402-monetize.md
@@ -102,7 +102,7 @@ Created with a facilitator client. Register payment schemes and extensions befor
 const { x402ResourceServer, HTTPFacilitatorClient } = require("@x402/core/server");
 const { ExactEvmScheme } = require("@x402/evm/exact/server");
 
-const facilitator = new HTTPFacilitatorClient({ url: "https://x402.org" });
+const facilitator = new HTTPFacilitatorClient({ url: "https://x402.org/facilitator" });
 const server = new x402ResourceServer(facilitator);
 server.register("eip155:8453", new ExactEvmScheme());
 ```


### PR DESCRIPTION
## Summary

Update the x402 server reference to use the correct facilitator base URL.

`HTTPFacilitatorClient` appends endpoint paths such as `/supported`, so using `https://x402.org` results in a 404. The correct base URL is `https://x402.org/facilitator`.