### PR TITLE
feat: add agent trust preflight before crypto delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A single skill — [`agentic-wallet`](./skills/agentic-wallet/SKILL.md) — that
 | Add funds via Coinbase Onramp | [`fund.md`](./skills/agentic-wallet/references/fund.md) |
 | Search the x402 bazaar for paid API services | [`x402-search.md`](./skills/agentic-wallet/references/x402-search.md) |
 | Pay an x402 endpoint with automatic USDC payment | [`x402-pay.md`](./skills/agentic-wallet/references/x402-pay.md) |
+| Vet an AI agent before delegating work or sending funds | [`agent-trust.md`](./skills/agentic-wallet/references/agent-trust.md) |
 | Build and deploy a paid API server (x402) | [`x402-monetize.md`](./skills/agentic-wallet/references/x402-monetize.md) |
 | Query onchain data on Base via the CDP SQL API | [`query-onchain.md`](./skills/agentic-wallet/references/query-onchain.md) |
 

--- a/skills/agentic-wallet/SKILL.md
+++ b/skills/agentic-wallet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentic-wallet
-description: "Crypto wallet operations via the awal CLI — sign in, check balances, send USDC/ETH/POL/SOL, trade tokens, fund the wallet, and use the x402 payment protocol to discover paid services, pay for API calls, monetize an API, or query onchain data. Use whenever the user mentions signing in, login, authentication, wallet status, balance, address, sending money, paying someone, transferring tokens, ENS names, swapping/trading/converting tokens, funding/topping up/onramp, USDC, ETH, POL, SOL, the x402 bazaar, paid APIs, monetizing an endpoint, or querying onchain data on Base."
+description: "Crypto wallet operations via the awal CLI — sign in, check balances, send USDC/ETH/POL/SOL, trade tokens, fund the wallet, and use the x402 payment protocol to discover paid services, pay for API calls, monetize an API, vet an AI agent before delegating or paying, or query onchain data. Use whenever the user mentions signing in, login, authentication, wallet status, balance, address, sending money, paying someone, transferring tokens, ENS names, swapping/trading/converting tokens, funding/topping up/onramp, USDC, ETH, POL, SOL, the x402 bazaar, paid APIs, agent trust or reputation, delegation, monetizing an endpoint, or querying onchain data on Base."
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: ["Bash(npx awal@2.12.1 *)", "Bash(npm *)", "Bash(node *)", "Bash(curl *)", "Bash(mkdir *)"]
@@ -33,6 +33,7 @@ Pick the reference that matches the task and `Read` it before acting:
 | Add funds, top up, onramp, buy USDC | `references/fund.md` |
 | Find / browse / search paid services on the x402 bazaar | `references/x402-search.md` |
 | Call a paid x402 API endpoint with automatic USDC payment | `references/x402-pay.md` |
+| Vet an AI agent or capability before delegating work or sending funds | `references/agent-trust.md` |
 | Build or deploy a paid API server that other agents can pay to use | `references/x402-monetize.md` |
 | Query onchain data on Base (events, transactions, blocks) via the CDP SQL API | `references/query-onchain.md` |
 

--- a/skills/agentic-wallet/references/agent-trust.md
+++ b/skills/agentic-wallet/references/agent-trust.md
@@ -1,6 +1,6 @@
 # Vetting an AI Agent Before Delegation or Payment
 
-Use Agent Guild as a preflight before delegating work to an unfamiliar AI agent or sending it funds. The free endpoint check reports observed evidence and preserves unknowns. Capability routing is available as a low-cost x402 read, with an optional higher-priced signed artifact for offline verification.
+Use Agent Guild as a preflight before delegating work to an unfamiliar AI agent or signing an x402 payment to an unfamiliar payee. The free endpoint check reports observed evidence and preserves unknowns. Exact-payment and capability decisions are available as low-cost x402 reads, with portable signed artifacts for offline verification.
 
 Agent Guild is an independent third-party service, not a Coinbase endorsement. Treat its decision as one input to your policy, not a guarantee of performance.
 
@@ -23,6 +23,50 @@ curl 'https://agent-guild-5d5r.onrender.com/preflight?url=https%3A%2F%2Fexample.
 ```
 
 Inspect the structured checks individually. Do not convert `unknown` payment, identity, or external-evidence fields into a pass. A reachable endpoint is not proof that the operator is trustworthy.
+
+## Exact-Payment Decision Before Signing
+
+Use this gate immediately before `x402 pay` when the selected Base payee is not already trusted. It buys a separate $0.01 Agent Guild decision; it does not pay the target service.
+
+First inspect the target without paying:
+
+```bash
+npx awal@2.12.1 x402 details 'https://seller.example/api/research' --json
+```
+
+Select exactly one advertised payment option. This flow currently supports only `scheme: exact` on Base mainnet (`eip155:8453`) with an EVM `payTo`. Copy these fields without normalization or substitution:
+
+- `scheme`
+- `network`
+- `asset`
+- atomic-unit `amount`
+- `payTo`
+- `resource.url`
+
+Submit those exact values for a signed decision. Replace each angle-bracket value only with the corresponding field from the `details` response:
+
+```bash
+npx awal@2.12.1 x402 pay 'https://agent-guild-5d5r.onrender.com/wallet-binding/decision' -X POST -d '{"payment":{"scheme":"exact","network":"eip155:8453","asset":"<selected asset>","amount":"<selected atomic amount>","pay_to":"<selected payTo>","resource":"<paymentRequired.resource.url>"},"policy":{"max_risk":32.99,"min_confidence":0.5},"ttl_seconds":300}' --max-amount 10000 --json
+```
+
+Before relying on the response, require all of the following:
+
+1. The credential `type` includes `AgentGuildPaymentDecision` and `credentialSubject.contract` is exactly `AGPD-1/1.0`.
+2. The issuer is the pinned production issuer `did:key:z6MkkSis851QCeP153LUWrxgSKRkSgy91BpUv5geXN7z4P6R` and the `eddsa-jcs-2022` proof verifies.
+3. The credential is currently valid and expires no more than one hour after issuance.
+4. Every `credentialSubject.payment` field exactly matches the selected target option, including payee, atomic amount, and resource.
+5. The effective risk thresholds are at least as strict as those requested.
+6. `credentialSubject.decision` is exactly `allow`.
+
+If any check fails, do not run the target `x402 pay`. A signed `block` for an unknown wallet means there is insufficient wallet-bound evidence; it does not accuse the seller of misconduct.
+
+Verification is free at `POST https://agent-guild-5d5r.onrender.com/wallet-binding/decision/verify`. Official x402 SDK clients can automate the same fail-closed gate with:
+
+```text
+https://agent-guild-5d5r.onrender.com/sdk/integrations/x402_payment_policy.mjs
+```
+
+Register `createAgentGuildX402PaymentPolicy({meteredFetch})` with `client.onBeforePaymentCreation(policy)`. `meteredFetch` must use a separate unguarded x402 client so paying for the policy decision does not recursively invoke itself.
 
 ## Low-Cost Capability Routing
 

--- a/skills/agentic-wallet/references/agent-trust.md
+++ b/skills/agentic-wallet/references/agent-trust.md
@@ -1,0 +1,90 @@
+# Vetting an AI Agent Before Delegation or Payment
+
+Use Agent Guild as a preflight before delegating work to an unfamiliar AI agent or sending it funds. The free checks report observed evidence and preserve unknowns; an optional x402 call returns a short-lived, signed capability decision.
+
+Agent Guild is an independent third-party service, not a Coinbase endorsement. Treat its decision as one input to your policy, not a guarantee of performance.
+
+## Input Validation
+
+Before placing a user-provided value in a shell command:
+
+- **capability**: lowercase letters, numbers, and hyphens only (`^[a-z0-9-]{1,64}$`).
+- **endpoint URL**: must start with `https://` and contain no spaces, semicolons, pipes, backticks, control characters, or other shell metacharacters. Percent-encode it before adding it to a query string.
+- Reject rather than repair invalid input.
+
+Do not pass unvalidated input into a command.
+
+## Free Endpoint Preflight
+
+If the candidate publishes an HTTPS endpoint, check what can be proved without payment:
+
+```bash
+curl 'https://agent-guild-5d5r.onrender.com/preflight?url=https%3A%2F%2Fexample.com%2Fa2a'
+```
+
+Inspect the structured checks individually. Do not convert `unknown` payment, identity, or external-evidence fields into a pass. A reachable endpoint is not proof that the operator is trustworthy.
+
+## Free Capability Check
+
+For a capability-level routing decision that does not need a signed artifact:
+
+```bash
+curl 'https://agent-guild-5d5r.onrender.com/check?capability=code-review'
+```
+
+Require an exact capability match. Inspect the verdict, ranked candidates, evidence, checkpoint, and uncertainty before delegating.
+
+## Optional Signed Decision via x402
+
+Use this only when the caller needs a portable, time-bounded decision that can be verified offline. First inspect the live payment requirements without paying:
+
+```bash
+npx awal@2.12.1 x402 details 'https://agent-guild-5d5r.onrender.com/check?capability=code-review&signed=true&ttl_seconds=3600' --json
+```
+
+Before paying, require all of the following:
+
+- HTTPS host is exactly `agent-guild-5d5r.onrender.com`.
+- Network is Base mainnet, scheme is `exact`, and the asset is Base USDC.
+- Amount is no more than 1,000,000 atomic units (1 USDC).
+- The caller has explicitly authorized this class of spend and the amount is within its policy.
+
+If any field differs, stop and surface the mismatch. Do not silently switch networks, assets, recipients, or amounts.
+
+After those checks pass:
+
+```bash
+npx awal@2.12.1 x402 pay 'https://agent-guild-5d5r.onrender.com/check?capability=code-review&signed=true&ttl_seconds=3600' --max-amount 1000000 --json
+```
+
+## Validate the Returned Decision
+
+Do not rely on the payment receipt alone. Validate the response before using it:
+
+1. `type` includes `AgentGuildDecision` and `contract` is `AGD-1/1.0`.
+2. `capability` exactly matches the requested capability.
+3. `issued_at` is not in the future and `valid_until` is still in the future.
+4. `issuer` is the pinned production issuer:
+   `did:key:z6MkkSis851QCeP153LUWrxgSKRkSgy91BpUv5geXN7z4P6R`.
+5. The `eddsa-jcs-2022` data-integrity proof verifies over the complete decision.
+6. The verdict, routing evidence, checkpoint, and unknown fields satisfy the caller's own delegation policy.
+
+The zero-dependency Node verifier is published at:
+
+```text
+https://agent-guild-5d5r.onrender.com/sdk/agentguild_verify.mjs
+```
+
+Pin or vendor a reviewed copy before relying on it. A verifier or issuer change requires re-review; do not auto-accept a new key.
+
+## Keep Payments Separate
+
+The x402 payment above purchases a trust decision. It does not pay the candidate agent for work. Negotiate scope and price separately, then use an escrow or an independently verifiable payment flow for the actual task. Preserve the signed decision, task terms, work receipt, and settlement evidence as separate artifacts.
+
+## Failure Handling
+
+- **No candidate or `avoid` verdict**: do not delegate or pay; select another capability or counterparty.
+- **`caution` verdict**: require stronger evidence, tighter limits, or human/policy escalation.
+- **Expired or invalid signature**: discard the artifact and request a fresh decision.
+- **Payment requirement mismatch**: do not pay.
+- **Service unavailable**: fail closed for high-risk transfers; do not treat an outage as approval.

--- a/skills/agentic-wallet/references/agent-trust.md
+++ b/skills/agentic-wallet/references/agent-trust.md
@@ -1,6 +1,6 @@
 # Vetting an AI Agent Before Delegation or Payment
 
-Use Agent Guild as a preflight before delegating work to an unfamiliar AI agent or sending it funds. The free checks report observed evidence and preserve unknowns; an optional x402 call returns a short-lived, signed capability decision.
+Use Agent Guild as a preflight before delegating work to an unfamiliar AI agent or sending it funds. The free endpoint check reports observed evidence and preserves unknowns. Capability routing is available as a low-cost x402 read, with an optional higher-priced signed artifact for offline verification.
 
 Agent Guild is an independent third-party service, not a Coinbase endorsement. Treat its decision as one input to your policy, not a guarantee of performance.
 
@@ -24,19 +24,35 @@ curl 'https://agent-guild-5d5r.onrender.com/preflight?url=https%3A%2F%2Fexample.
 
 Inspect the structured checks individually. Do not convert `unknown` payment, identity, or external-evidence fields into a pass. A reachable endpoint is not proof that the operator is trustworthy.
 
-## Free Capability Check
+## Low-Cost Capability Routing
 
-For a capability-level routing decision that does not need a signed artifact:
+For a capability-level routing decision that does not need a portable signed artifact, first inspect the live x402 terms without paying:
 
 ```bash
-curl 'https://agent-guild-5d5r.onrender.com/check?capability=code-review'
+npx awal@2.12.1 x402 details 'https://agent-guild-5d5r.onrender.com/check?capability=code-review&signed=false&ttl_seconds=3600' --json
 ```
 
-Require an exact capability match. Inspect the verdict, ranked candidates, evidence, checkpoint, and uncertainty before delegating.
+Before paying, require all of the following:
+
+- HTTPS host is exactly `agent-guild-5d5r.onrender.com`.
+- Scheme is `exact` and network is exactly Base mainnet (`eip155:8453`).
+- Asset is exactly Base USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`).
+- Recipient is exactly the pinned Agent Guild settlement address
+  `0xaa4E3ba0Eb5f564cAb54dDC08f5BaAfb3D4cA8E5`.
+- Amount is no more than 10,000 atomic units (0.01 USDC).
+- The caller has explicitly authorized this class of spend and the amount is within its policy.
+
+If those checks pass:
+
+```bash
+npx awal@2.12.1 x402 pay 'https://agent-guild-5d5r.onrender.com/check?capability=code-review&signed=false&ttl_seconds=3600' --max-amount 10000 --json
+```
+
+Require an exact capability match. Inspect `decision`, `routing`, evidence provenance, confidence, staleness, reachability, value at risk, and unknown fields before delegating. A null decision or unreachable candidate is not approval.
 
 ## Optional Signed Decision via x402
 
-Use this only when the caller needs a portable, time-bounded decision that can be verified offline. First inspect the live payment requirements without paying:
+Use this only when the caller needs a portable, time-bounded decision that can be verified offline. It is a separate purchase from the low-cost routing read. First inspect the live payment requirements without paying:
 
 ```bash
 npx awal@2.12.1 x402 details 'https://agent-guild-5d5r.onrender.com/check?capability=code-review&signed=true&ttl_seconds=3600' --json
@@ -45,7 +61,10 @@ npx awal@2.12.1 x402 details 'https://agent-guild-5d5r.onrender.com/check?capabi
 Before paying, require all of the following:
 
 - HTTPS host is exactly `agent-guild-5d5r.onrender.com`.
-- Network is Base mainnet, scheme is `exact`, and the asset is Base USDC.
+- Scheme is `exact` and network is exactly Base mainnet (`eip155:8453`).
+- Asset is exactly Base USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`).
+- Recipient is exactly the pinned Agent Guild settlement address
+  `0xaa4E3ba0Eb5f564cAb54dDC08f5BaAfb3D4cA8E5`.
 - Amount is no more than 1,000,000 atomic units (1 USDC).
 - The caller has explicitly authorized this class of spend and the amount is within its policy.
 
@@ -61,7 +80,7 @@ npx awal@2.12.1 x402 pay 'https://agent-guild-5d5r.onrender.com/check?capability
 
 Do not rely on the payment receipt alone. Validate the response before using it:
 
-1. `type` includes `AgentGuildDecision` and `contract` is `AGD-1/1.0`.
+1. `type` is exactly `AgentGuildDecision` and `contract` is `AGD-1/1.0`.
 2. `capability` exactly matches the requested capability.
 3. `issued_at` is not in the future and `valid_until` is still in the future.
 4. `issuer` is the pinned production issuer:
@@ -76,6 +95,7 @@ https://agent-guild-5d5r.onrender.com/sdk/agentguild_verify.mjs
 ```
 
 Pin or vendor a reviewed copy before relying on it. A verifier or issuer change requires re-review; do not auto-accept a new key.
+The verifier's exported `verifyCredential()` function validates the same `DataIntegrityProof` used by signed decisions and passports.
 
 ## Keep Payments Separate
 

--- a/skills/agentic-wallet/references/x402-pay.md
+++ b/skills/agentic-wallet/references/x402-pay.md
@@ -45,6 +45,12 @@ Before constructing the command, validate all user-provided values to prevent sh
 
 Do not pass unvalidated user input into the command.
 
+## Gate Unfamiliar Payees Before Signing
+
+Before paying an x402 option whose `payTo` is not already trusted, inspect it with `x402 details --json`, then follow **Exact-Payment Decision Before Signing** in `references/agent-trust.md`.
+
+The Agent Guild decision is a separate $0.01 x402 purchase that binds the exact scheme, network, asset, atomic amount, payee, and resource into a short-lived signed credential. Do not execute the target payment unless that credential verifies and says `allow`. Unknown or unbound wallets fail closed without being labelled as malicious.
+
 ## Examples
 
 ```bash


### PR DESCRIPTION
## What this adds

A compact, machine-first trust preflight for wallet agents that are about to pay, hire, or delegate to another agent.

- Free endpoint and credential preflight before payment.
- A separate **$0.01 AGPD-1 exact-payment decision** for an unfamiliar Base x402 payee before the target payment is signed.
- Optional **$0.01 capability routing** over x402 when the wallet needs a ranked supplier decision.
- Optional **$1 signed portable decision** when a routing result must be carried or verified offline.
- Fail-closed verification of returned signed credentials.
- Exact Base mainnet settlement pins: `eip155:8453`, native USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`, and Agent Guild treasury `0xaa4E3ba0Eb5f564cAb54dDC08f5BaAfb3D4cA8E5`.

## Why it belongs in the wallet skill

Agentic wallets already know how to inspect and pay x402 resources. This adds a default decision gate at the irreversible point: the wallet reads the target challenge, copies its exact scheme, network, asset, atomic amount, payee, resource, and capability into an AGPD-1 request, then verifies the signed `allow` decision before creating the target payment.

The credential layer is vendor-neutral and independently verifiable. A wallet rejects a decision whose signature, issuer, expiry, payment binding, evidence, or effective thresholds differ from policy. An unknown payee is treated as a block, not as an accusation of misconduct.

## Validation

Validated against the published `awal@2.12.1` package and the live production endpoint:

- `awal x402 details --json` exposes the target resource and accepted payment requirements needed for the binding.
- `POST /wallet-binding/decision` advertises an exact **10,000 atomic-unit ($0.01 USDC)** challenge on Base mainnet.
- The challenge pins the production USDC asset, Agent Guild treasury, and request-hash-bound resource.
- `git diff --check` passes for the documentation update.
- No payment was made during validation.

## Scope

Four documentation-only files:

- `README.md`
- `skills/agentic-wallet/SKILL.md`
- `skills/agentic-wallet/references/agent-trust.md`
- `skills/agentic-wallet/references/x402-pay.md`

All six commits were created through GitHub's signed web flow and show as **Verified**.